### PR TITLE
dependabot config for Terraform

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -7,7 +7,7 @@ if [ -z "$EKS_CLUSTER_NAME" ]; then
   exit 1
 fi
 
-aws eks update-kubeconfig --name $EKS_CLUSTER_NAME 
+aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
 
 kubectl get nodes &> /dev/null
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds dependabot configuration to update Terraform modules and provider versions.

Dependabot is already configured on the repository for Python, so nothing else should be needed other than merging this PR to enable it for Terraform.

Version 4.6.1 of eks-blueprints is available so it should create PR to upgrade once this is merged

#### Quality checks
I tested the functionality in a separate repo.
