### PR TITLE
specify individual paths for terraform projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,26 @@ updates:
     schedule:
       interval: monthly
   - package-ecosystem: "terraform" 
-    directory: "/terraform" 
+    directory: "/terraform/cluster-only" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" 
+    directory: "/terraform/full" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" 
+    directory: "/terraform/local" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" 
+    directory: "/terraform/modules/cluster" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" 
+    directory: "/terraform/modules/ide" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform" 
+    directory: "/terraform/modules/addons/descheduler" 
     schedule:
       interval: "weekly"


### PR DESCRIPTION
#### What this PR does / why we need it:

Enable Dependabot to create PRs for Terraform modules updates. Need to specify individual paths of each folder that contains a Terraform 'project' we want to auto-update.