### PR TITLE
feat: Horizontal Cluster Proportional Autoscaler sub-module

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2022
 
 RUN yum install -y findutils aws-cli jq tar gzip && \
     yum clean all

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -10,4 +10,4 @@ bash $SCRIPT_DIR/create-infrastructure.sh
 
 bash $SCRIPT_DIR/run-tests.sh
 
-#bash $SCRIPT_DIR/destroy-infrastructure.sh
+bash $SCRIPT_DIR/destroy-infrastructure.sh

--- a/site/content/autoscaling/cpa/_index.md
+++ b/site/content/autoscaling/cpa/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Horizontal Cluster Proportional Autoscaler"
 chapter: true
-weight: 1
+weight: 15
 ---
 
 # Cluster Proportional Autoscaler

--- a/site/content/autoscaling/cpa/install.md
+++ b/site/content/autoscaling/cpa/install.md
@@ -91,7 +91,7 @@ spec:
           - --target=Deployment/coredns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.
-          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
+          - --default-params={"linear":{"nodesPerReplica":2,"min":2,"max":6,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
           - --logtostderr=true
           - --v=2
       tolerations:
@@ -99,9 +99,7 @@ spec:
         operator: "Exists"
       serviceAccountName: dns-autoscaler
 EOF
-```
 
-```bash
 kubectl apply -f cpa-install.yaml
 ```
 

--- a/site/content/autoscaling/cpa/tests/hook-cpa-cleanup.sh
+++ b/site/content/autoscaling/cpa/tests/hook-cpa-cleanup.sh
@@ -1,0 +1,23 @@
+set -Eeuo pipefail
+
+before() {
+  echo "noop"
+}
+
+after() {
+  timeout -s TERM 160 bash -c \
+    "while [[ $(kubectl get po -n kube-system -l k8s-app=kube-dns -o json | jq -r '.items | length') -lt 3 ]];\
+    do echo 'Waiting for CoreDNS to scale' && sleep 30;\
+    done"
+
+  if [ $? -ne 0 ]; then
+    cat << EOF >&2
+Core DNS pods did not scale up
+$(kubectl get po -n kube-system -l k8s-app=kube-dns)
+$(kubectl get nodes)
+EOF
+    exit 1
+  fi
+}
+
+"$@"

--- a/site/content/autoscaling/cpa/tests/hook-cpa-pod-scaleout.sh
+++ b/site/content/autoscaling/cpa/tests/hook-cpa-pod-scaleout.sh
@@ -1,0 +1,23 @@
+set -Eeuo pipefail
+
+before() {
+  echo "noop"
+}
+
+after() {
+  timeout -s TERM 160 bash -c \
+    "while [[ $(kubectl get po -n kube-system -l k8s-app=kube-dns -o json | jq -r '.items | length') -lt 3 ]];\
+    do echo 'Waiting for CoreDNS to scale' && sleep 30;\
+    done"
+
+  if [ $? -ne 0 ]; then
+    cat << EOF >&2
+Core DNS pods did not scale up
+$(kubectl get po -n kube-system -l k8s-app=kube-dns)
+$(kubectl get nodes)
+EOF
+    exit 1
+  fi
+}
+
+"$@"


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding Cluster proportional autoscaler sub-module to the core autoscaling module. This is for eks workshop v2.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [Yes ] My content adheres to the style guidelines
- [ Yes] I ran `make test` or `make e2e-test` and it was successful

make test module='autoscaling/cpa'
bash hack/run-tests.sh autoscaling/cpa
Running tests for module autoscaling/cpa
Generating temporary AWS credentials...
Running test suite...
Added new context arn:aws:eks:us-west-2:xxxxxxxxx:cluster/eks-workshop-cluster to /root/.kube/config
- Generating test cases
✔ Generating test cases
- Building Mocha suites
✔ Building Mocha suites

Executing tests...
  Root
    Autoscaling
      Horizontal Cluster Proportional Autoscaler
        - Horizontal Cluster Proportional Autoscaler
        ✔ CPA Install (5015ms)
        ✔ Autoscaling CoreDNS Using Cluster Proportional Autoscaler (13947ms)
        ✔ Clean Up (183477ms)


  3 passing (3m)
  1 pending

success