### PR TITLE
feature: Bump EKS version to 1.23

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2022
 RUN yum install -y findutils aws-cli jq tar gzip zsh git diffutils wget && \
     yum clean all
 
-RUN curl -LO https://dl.k8s.io/release/v1.22.12/bin/linux/amd64/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.23.9/bin/linux/amd64/kubectl && \
   chmod +x ./kubectl && \
   mv ./kubectl /usr/local/bin
 

--- a/terraform/modules/cluster/variables.tf
+++ b/terraform/modules/cluster/variables.tf
@@ -1,7 +1,7 @@
 variable "cluster_version" {
   type        = string
   description = "Kubernetes Version"
-  default     = "1.22"
+  default     = "1.23"
 }
 
 variable "id" {


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrades workshop to EKS version 1.23

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful