### PR TITLE
chore: Added Terraform verify to CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,15 @@ jobs:
     - name: Verify helm chart yaml
       run: |
         make verify-helm-metadata
+  verify-terraform:
+    name: verify-terraform
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v2
+    - name: Verify terraform
+      working-directory: terraform/local
+      run: |
+        terraform init -backend=false
+        terraform validate -no-color


### PR DESCRIPTION
#### What this PR does / why we need it:

Added Terraform verify to CI jobs to perform basic validation that Terraform configuration is still valid without a full apply.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful