### PR TITLE
enable prefix networking mode by default

### DIFF
--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -14,16 +14,6 @@ data "aws_eks_cluster_auth" "cluster" {
   name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
 }
 
-data "aws_ssm_parameter" "eks_optimized_ami" {
-  name = "/aws/service/eks/optimized-ami/${local.cluster_version}/amazon-linux-2/recommended/image_id"
-}
-
-data "aws_eks_addon_version" "latest" {
-  for_each = toset(["vpc-cni"])
-  addon_name = each.value
-  kubernetes_version = local.cluster_version
-}
-
 provider "aws" {
   region = data.aws_region.current.id
   alias  = "default"


### PR DESCRIPTION
#### What this PR does / why we need it:
This enables prefix networking mode upon cluster creation

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test` or `make e2e-test` and it was successful