### PR TITLE
chore: EKS blueprints addons depends_on

### DIFF
--- a/terraform/modules/cluster/addons.tf
+++ b/terraform/modules/cluster/addons.tf
@@ -7,6 +7,10 @@ resource "kubernetes_namespace" "workshop_system" {
 module "eks-blueprints-kubernetes-addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.10.0//modules/kubernetes-addons"
 
+  depends_on = [
+    module.aws-eks-accelerator-for-terraform
+  ]
+
   eks_cluster_id = module.aws-eks-accelerator-for-terraform.eks_cluster_id
 
   enable_karpenter                     = true


### PR DESCRIPTION
#### What this PR does / why we need it:

Added explicit depends on so node groups and Fargate are up before addons try to install. Currently pods spun up by addons can end up on EC2 nodes instead of Fargate etc.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful