### PR TITLE
Adding cleanup mechanism for infrastructure

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -26,6 +26,16 @@ jobs:
       with:
         terraform_version: 1.2.9
         terraform_wrapper: false
+    - name: Install utilities
+      run: |
+        sudo apt install -y gettext
+
+        mkdir -p ${HOME}/.local/bin
+        wget https://github.com/jckuester/awsweeper/releases/download/v0.12.0/awsweeper_0.12.0_linux_amd64.tar.gz
+        tar zxf awsweeper_0.12.0_linux_amd64.tar.gz
+        mv awsweeper_0.12.0_linux_amd64/awsweeper ${HOME}/.local/bin
+
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
     - name: Get AWS credentials
       uses: aws-actions/configure-aws-credentials@v1.6.1
       with:
@@ -95,7 +105,7 @@ jobs:
         DEV_MODE: 1
       run: |
         make test terraform_context="test/terraform" module="{observability,observability/**}"
-    - name: Run tests - Observability
+    - name: Run tests - Cost optimization
       if: ${{ github.event_name == 'workflow_dispatch' || contains( github.event.pull_request.labels.*.name, 'content/cost-optimization') }}
       env:
         DOCKER_BUILDKIT: 1
@@ -126,5 +136,8 @@ jobs:
         terraform destroy -target=module.core.module.cluster.module.descheduler --auto-approve
 
         terraform destroy -target=module.core.module.cluster.module.eks-blueprints --auto-approve
+
+        envsubst < ../../hack/lib/filter.yml > filter.yml
+        awsweeper --force filter.yml
 
         terraform destroy --auto-approve

--- a/hack/create-infrastructure.sh
+++ b/hack/create-infrastructure.sh
@@ -3,7 +3,7 @@
 environment=$1
 terraform_context=$2
 
-set -e
+set -Eeuo pipefail
 
 if [ -z "$environment" ]; then
   echo 'Error: Must provide environment name'

--- a/hack/lib/filter.yml
+++ b/hack/lib/filter.yml
@@ -1,0 +1,13 @@
+aws_lb:
+  - tags:
+      elbv2.k8s.aws/cluster: eks-workshop-${CLUSTER_ID}
+aws_lb_target_group:
+  - tags:
+      elbv2.k8s.aws/cluster: eks-workshop-${CLUSTER_ID}
+aws_security_group:
+  - tags:
+      elbv2.k8s.aws/cluster: eks-workshop-${CLUSTER_ID}
+aws_ebs_volume:
+  - tags:
+      KubernetesCluster: eks-workshop-${CLUSTER_ID}
+      ebs.csi.aws.com/cluster: true


### PR DESCRIPTION
#### What this PR does / why we need it:

In some cases resources provisioned in EKS such as load balancers and EBS volumes can be left over if cleanup does not run properly, as well as dangling ENIs from the VPC CNI. These will tend to prevent the Terraform from completing a destroy and result in additional incurred cost until manual cleanup.

This change adds an additional round of cleanup after the EKS cluster and its main resources have been destroyed to target the specific problematic resources.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful