### PR TITLE
Mac M1 - Unable to find image

### DIFF
--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -5,6 +5,9 @@ module=$2
 
 set -Eeuo pipefail
 
+# Right now the container images are only designed for amd64
+export DOCKER_DEFAULT_PLATFORM=linux/amd64 
+
 if [[ "$module" == "*" ]]; then
   echo 'Error: Please specify a module'
   exit 1
@@ -23,9 +26,6 @@ container_image='eks-workshop-test'
 (cd $SCRIPT_DIR/../test && docker build -q -t $container_image .)
 
 source $SCRIPT_DIR/lib/generate-aws-creds.sh
-
-# Right now the container images are only designed for amd64
-export DOCKER_DEFAULT_PLATFORM=linux/amd64 
 
 echo "Running test suite..."
 

--- a/hack/shell.sh
+++ b/hack/shell.sh
@@ -4,6 +4,9 @@ terraform_context=$1
 
 set -Eeuo pipefail
 
+# Right now the container images are only designed for amd64
+export DOCKER_DEFAULT_PLATFORM=linux/amd64 
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 source $SCRIPT_DIR/lib/terraform-context.sh
@@ -15,9 +18,6 @@ container_image='eks-workshop-environment'
 (cd $SCRIPT_DIR/../environment && docker build -q -t $container_image .)
 
 source $SCRIPT_DIR/lib/generate-aws-creds.sh
-
-# Right now the container images are only designed for amd64
-export DOCKER_DEFAULT_PLATFORM=linux/amd64 
 
 echo "Starting shell in container..."
 


### PR DESCRIPTION
#### What this PR does / why we need it:
set env variable before docker build to prevent "Unable to find image 'eks-workshop-test:latest' locally" when running make shell or make test

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ X] My content adheres to the style guidelines
- [ X] I ran `make test` or `make e2e-test` and it was successful