### PR TITLE
Hide MQ content from ACK section

### DIFF
--- a/environment/workspace/modules/ack/manifests/kustomization.yaml
+++ b/environment/workspace/modules/ack/manifests/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - assets
 - orders
 - ui
+# TODO Delete the next line after MQ ACK issue is resolved MQ issue in ACK is resolved https://github.com/aws-controllers-k8s/community/issues/1517
+- rabbitmq

--- a/environment/workspace/modules/ack/manifests/orders/configMap.yaml
+++ b/environment/workspace/modules/ack/manifests/orders/configMap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orders
+data:
+  SPRING_RABBITMQ_HOST: rabbitmq.rabbitmq-prod.svc

--- a/environment/workspace/modules/ack/manifests/rabbitmq/kustomization.yaml
+++ b/environment/workspace/modules/ack/manifests/rabbitmq/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rabbitmq-prod
+bases:
+- ../../../../manifests/rabbitmq

--- a/website/docs/gitops/controlplanes/ack/configureApplicaiton.md
+++ b/website/docs/gitops/controlplanes/ack/configureApplicaiton.md
@@ -11,13 +11,10 @@ The application will use the same manifest files as in development, then we will
 $ kubectl apply -k /workspace/modules/ack/manifests/
 ...
 namespace/catalog-prod created
-namespace/orders-prod created
 ...
 service/catalog created
-service/orders created
 ...
 deployment.apps/catalog created
-deployment.apps/orders created
 ...
 ```
 
@@ -70,6 +67,7 @@ $ kubectl rollout restart deployment -n catalog-prod catalog
 deployment.apps/catalog restarted
 ```
 
+<!-- TODO: Uncomment once MQ issue in ACK is resolved https://github.com/aws-controllers-k8s/community/issues/1517
 ## Connect to Amazon MQ Instance
 The `Broker` status contains the information for connecting to the MQ instance. The endpoint information can be found in `status.brokerInstances[0].endpoints[0]` and the password can be found in `.spec.users[0].username`.
 
@@ -111,6 +109,7 @@ Restart orders to pickup the new configuration
 $ kubectl rollout restart deployment -n orders-prod orders
 deployment.apps/orders restarted
 ```
+-->
 
 ## Access the Application
 

--- a/website/docs/gitops/controlplanes/ack/configureResources.md
+++ b/website/docs/gitops/controlplanes/ack/configureResources.md
@@ -38,6 +38,9 @@ securitygroup.ec2.services.k8s.aws/rds-eks-workshop created
 dbinstance.rds.services.k8s.aws/rds-eks-workshop created
 dbsubnetgroup.rds.services.k8s.aws/rds-eks-workshop created
 ```
+
+
+<!-- TODO: Uncomment once MQ issue in ACK is resolved https://github.com/aws-controllers-k8s/community/issues/1517
 ## Create Amazon MQ Broker 
 
 Set Broker admin user password
@@ -66,3 +69,4 @@ After 10 minutes you can see in the AWS Console the RDS and MQ resouces are avai
 
 Continue to the next section to export the binding information from the provisioned AWS managed services.
 
+-->

--- a/website/docs/gitops/controlplanes/ack/installACK.md
+++ b/website/docs/gitops/controlplanes/ack/installACK.md
@@ -103,6 +103,8 @@ You are now able to create Amazon Relational Database Service (RDS) resources!
 ...
 ```
 
+
+<!-- TODO: Uncomment once MQ issue in ACK is resolved https://github.com/aws-controllers-k8s/community/issues/1517
 ## MQ controller setup
 Create the IAM role with the trust relationship with the Service Account for the MQ Controller. This time we use the IAM controller itself to create the role.
 
@@ -128,3 +130,4 @@ STATUS: deployed
 ...
 You are now able to create Amazon MQ (MQ) resources!
 ```
+-->


### PR DESCRIPTION
#### What this PR does / why we need it:

There is an [issue in ACK](https://github.com/aws-controllers-k8s/community/issues/1517) that doesn't allow to create a rabbit MQ resources, we are going to remove the content until the fix is fixed.

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful