### PR TITLE
flip affinity module flow

### DIFF
--- a/environment/workspace/modules/fundamentals/affinity/checkout-redis/checkout-redis.yaml
+++ b/environment/workspace/modules/fundamentals/affinity/checkout-redis/checkout-redis.yaml
@@ -9,15 +9,6 @@ spec:
   template:
     spec:
       affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - service
-            topologyKey: kubernetes.io/hostname
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/environment/workspace/modules/fundamentals/affinity/checkout/checkout.yaml
+++ b/environment/workspace/modules/fundamentals/affinity/checkout/checkout.yaml
@@ -7,6 +7,15 @@ spec:
   template:
     spec:
       affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - redis
+            topologyKey: kubernetes.io/hostname
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/website/docs/fundamentals/managed-node-groups/affinity/index.md
+++ b/website/docs/fundamentals/managed-node-groups/affinity/index.md
@@ -2,11 +2,11 @@
 title: Pod Affinity and Anti-Affinity
 sidebar_position: 30
 ---
-Pods can be constrained to run on specific nodes or under specific circumstances. This can include cases where you want only one Pod running per node or want Pods to be paired together on a node. Additionally, when using node affinity Pods can have preferred or mandatory restrictions.
+Pods can be constrained to run on specific nodes or under specific circumstances. This can include cases where you want only one pod running per node or want pods to be paired together on a node. Additionally, when using node affinity pods can have preferred or mandatory restrictions.
 
-For this lesson, we will focus on inter-Pod affinity and anti-affinity by scheduling the `checkout` Pods to run only one instance per node and by scheduling the `checkout-redis` Pods to only run on nodes where a `checkout` Pod exists. This will ensure that our caching Pods (`checkout-redis`) run locally with a `checkout` Pod instance for best performance. 
+For this lesson, we will focus on inter-pod affinity and anti-affinity by scheduling the `checkout-redis` pods to run only one instance per node and by scheduling the `checkout` pods to only run one instance of it on nodes where a `checkout-redis` pod exists. This will ensure that our caching pods (`checkout-redis`) run locally with a `checkout` pod instance for best performance. 
 
-The first thing we want to do is see that the `checkout` and `checkout-redis` Pods are running:
+The first thing we want to do is see that the `checkout` and `checkout-redis` pods are running:
 
 ```bash
 $ kubectl get pods -n checkout
@@ -15,7 +15,7 @@ checkout-698856df4d-vzkzw         1/1     Running   0          125m
 checkout-redis-6cfd7d8787-kxs8r   1/1     Running   0          127m
 ```
 
-We can see both applications have one Pod running in the cluster. Now let's find out where they are running:
+We can see both applications have one pod running in the cluster. Now let's find out where they are running:
 
 ```bash
 $ kubectl get pods -n checkout \
@@ -24,15 +24,15 @@ checkout-698856df4d-vzkzw       ip-10-42-11-142.us-west-2.compute.internal
 checkout-redis-6cfd7d8787-kxs8r ip-10-42-10-225.us-west-2.compute.internal
 ```
 
-Based on the results above, the `checkout-698856df4d-vzkzw` Pod is running on the `ip-10-42-11-142.us-west-2.compute.internal` node while the `checkout-redis-6cfd7d8787-kxs8r` Pod is running on the `ip-10-42-10-225.us-west-2.compute.internal` node.
+Based on the results above, the `checkout-698856df4d-vzkzw` pod is running on the `ip-10-42-11-142.us-west-2.compute.internal` node and the `checkout-redis-6cfd7d8787-kxs8r` pod is running on the `ip-10-42-10-225.us-west-2.compute.internal` node.
 
 :::note
-In your environment the Pods may be running on the same node initially
+In your environment the pods may be running on the same node initially
 :::
 
-Let's set up a `podAntiAffinity` policy in the **checkout** deployment specifying that any Pods matching `app.kubernetes.io/component=service` can not be scheduled on the same node. We will use the `requiredDuringSchedulingIgnoredDuringExecution` to make this a requirement, rather than a preferred behavior.
+Let's set up a `podAffinity` and `podAntiAffinity` policy in the **checkout** deployment to ensure that one `checkout` pod runs per node, and that it will only run on nodes where a `checkout-redis` pod is already running. We will use the `requiredDuringSchedulingIgnoredDuringExecution` to make this a requirement, rather than a preferred behavior.
 
-The following kustomization adds an `affinity` section to the **checkout** deployment specifying a **podAntiAffinity** policy:
+The following kustomization adds an `affinity` section to the **checkout** deployment specifying both **podAffinity** and **podAntiAffinity** policies:
 
 ```kustomization
 fundamentals/affinity/checkout/checkout.yaml
@@ -54,25 +54,25 @@ $ kubectl rollout status deployment/checkout \
   -n checkout --timeout 180s
 ```
 
-The **podAntiAffinity** section requires that no `checkout` Pods are already running on the node by matching the **`app.kubernetes.io/component=service`** label. Now lets scale up the Deployment to check the configuration is working:
+The **podAffinity** section ensures that a `checkout-redis` pod is already running on the node — this is because we can assume the `checkout` pod requires `checkout-redis` to run correctly. The **podAntiAffinity** section requires that no `checkout` pods are already running on the node by matching the **`app.kubernetes.io/component=service`** label. Now lets scale up the deployment to check the configuration is working:
 
 ```bash
 $ kubectl scale -n checkout deployment/checkout --replicas 2
 ```
 
-Now validate where each Pod is running:
+Now validate where each pod is running:
 
 ```bash
 $ kubectl get pods -n checkout \
   -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\n"}'
-checkout-5b68c8cddf-bn8bp       ip-10-42-11-142.us-west-2.compute.internal
-checkout-5b68c8cddf-clnps       ip-10-42-12-31.us-west-2.compute.internal
-checkout-redis-6cfd7d8787-kxs8r ip-10-42-10-225.us-west-2.compute.internal
+checkout-6c7c9cdf4f-p5p6q       ip-10-42-10-120.us-west-2.compute.internal
+checkout-6c7c9cdf4f-wwkm4
+checkout-redis-6cfd7d8787-gw59j ip-10-42-10-120.us-west-2.compute.internal
 ```
 
-In this example the `checkout` Pods are running on separate nodes `ip-10-42-12-31.us-west-2.compute.internal` and `ip-10-42-11-142.us-west-2.compute.internal`, as required by the **podAntiAffinity** policy we defined in the deployment.
+In this example, the first `checkout` pod runs on the same pod as the existing checkout-redis pod, as it fulfills the **podAffinity** rule we set. The second one is still pending, because the **podAntiAffinity** rule we defined does not allow two checkout pods to get started on the same node. As the second node doesn't have a `checkout-redis` pod running, it will stay pending.
 
-Next, let's modify the `checkout-redis` deployment policies to require that future Pods both run individually per node and only run on nodes where a `checkout` Pod exists. To do this we will need to update the `checkout-redis` deployment specifying both a **podAffinity** and **podAntiAffinity** policy.:
+Next, we will scale the `checkout-redis` to two instances for our two nodes, but first let's modify the `checkout-redis` deployment policy to spread out our `checkout-redis` instances across each node. To do this, we will simply need to create a **podAntiAffinity** rule.
 
 ```kustomization
 fundamentals/affinity/checkout-redis/checkout-redis.yaml
@@ -94,13 +94,13 @@ $ kubectl rollout status deployment/checkout-redis \
   -n checkout --timeout 180s
 ```
 
-For the `checkout-redis` deployment we are adding **podAffinity** and **podAntiAffinity** fields. The **podAffinity** section requires that a `checkout` Pod exist on the node before deploying by matching the **`app.kubernetes.io/component=service`** label. The **podAntiAffinity** section requires that no `checkout-redis` Pods are already running on the node by matching the **`app.kubernetes.io/component=redis`** label.
+The **podAntiAffinity** section requires that no `checkout-redis` pods are already running on the node by matching the **`app.kubernetes.io/component=redis`** label.
 
 ```bash
 $ kubectl scale -n checkout deployment/checkout-redis --replicas 2
 ```
 
-Check the running Pods to verify that there are now two of each running:
+Check the running pods to verify that there are now two of each running:
 
 ```bash
 $ kubectl get pods -n checkout                                       
@@ -111,7 +111,7 @@ checkout-redis-7979df659-cjfbf   1/1     Running   0          19s
 checkout-redis-7979df659-pc6m9   1/1     Running   0          22s
 ```
 
-We can also verify where the Pods are running to ensure the **podAffinity** and **podAntiAffinity** policies are being followed:
+We can also verify where the pods are running to ensure the **podAffinity** and **podAntiAffinity** policies are being followed:
 
 ```bash
 $ kubectl get pods -n checkout \
@@ -122,25 +122,25 @@ checkout-redis-7979df659-57xcb  ip-10-42-11-142.us-west-2.compute.internal
 checkout-redis-7979df659-r7kkm  ip-10-42-12-31.us-west-2.compute.internal
 ```
 
-All looks good on the Pod scheduling, but we can further verify by scaling the `checkout-redis` Pod again to see where a third Pod will deploy:
+All looks good on the pod scheduling, but we can further verify by scaling the `checkout` pod again to see where a third pod will deploy:
 
 ```bash
-$ kubectl scale --replicas=3 deployment/checkout-redis --namespace checkout
+$ kubectl scale --replicas=3 deployment/checkout --namespace checkout
 ```
 
-If we check the running Pods we can see that the third `checkout-redis` Pod has been placed in a **Pending** state since there are only two nodes and both already have a Pod deployed:
+If we check the running pods we can see that the third `checkout` pod has been placed in a **Pending** state since there are only two nodes and both already have a pod deployed:
 
 ```bash
 $ kubectl get pods -n checkout
 NAME                             READY   STATUS    RESTARTS   AGE
 checkout-5b68c8cddf-bn8bp        1/1     Running   0          4m59s
 checkout-5b68c8cddf-clnps        1/1     Running   0          6m9s
+checkout-5b68c8cddf-lb69n        0/1     Pending   0          6s
 checkout-redis-7979df659-57xcb   1/1     Running   0          35s
-checkout-redis-7979df659-lb69n   0/1     Pending   0          6s
 checkout-redis-7979df659-r7kkm   1/1     Running   0          2m10s
 ```
 
-Lets finish this section by removing the Pending Pod:
+Lets finish this section by removing the Pending pod:
 
 ```bash
 $ kubectl scale --replicas=2 deployment/checkout-redis --namespace checkout


### PR DESCRIPTION
Currently the checkout-redis pod requires that the checkout pod is running. This is flipped — updated module to fix this. 