### PR TITLE
fix: Cloud9 bootstrap process should run idempotently

### DIFF
--- a/environment/installer.sh
+++ b/environment/installer.sh
@@ -71,7 +71,7 @@ rm -rf kustomize.tar.gz
 # aws cli v2
 curl --location --show-error --silent "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -o -q awscliv2.zip
-./aws/install
+./aws/install --update
 rm -rf ./aws awscliv2.zip
 
 # kubeseal

--- a/terraform/ide.tf
+++ b/terraform/ide.tf
@@ -44,6 +44,8 @@ GITOPS_SSH_SSM_NAME=${module.cluster.gitops_ssh_ssm_name}
 EOT
 
   bootstrap_script = <<EOF
+set -e
+
 rm -rf /tmp/workshop-repository
 git clone https://github.com/aws-samples/eks-workshop-v2 /tmp/workshop-repository
 (cd /tmp/workshop-repository && git checkout ${var.repository_ref})
@@ -84,6 +86,8 @@ EOT
 
 chown ec2-user /home/ec2-user/.bashrc.d/env.bash
 
+sudo rm -f /home/ec2-user/.ssh/gitops_ssh.pem
+
 sudo -H -u ec2-user bash -c "aws ssm get-parameter --name ${module.cluster.gitops_ssh_ssm_name} --with-decryption --query 'Parameter.Value' --region ${data.aws_region.current.name} --output text > ~/.ssh/gitops_ssh.pem"
 chmod 400 /home/ec2-user/.ssh/gitops_ssh.pem
 
@@ -110,7 +114,6 @@ module "ide" {
   cloud9_owner     = var.cloud9_owner
 
   additional_cloud9_policy_arns = [
-    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
     "arn:aws:iam::aws:policy/AdministratorAccess"
   ]
 

--- a/terraform/modules/cluster/codecommit.tf
+++ b/terraform/modules/cluster/codecommit.tf
@@ -11,7 +11,7 @@ resource "aws_iam_user" "gitops" {
 resource "aws_iam_user_ssh_key" "gitops" {
   username   = aws_iam_user.gitops.name
   encoding   = "SSH"
-  public_key = tls_private_key.gitops.public_key_pem
+  public_key = tls_private_key.gitops.public_key_openssh
 }
 
 resource "tls_private_key" "gitops" {

--- a/terraform/modules/cluster/efs.tf
+++ b/terraform/modules/cluster/efs.tf
@@ -16,6 +16,7 @@ resource "aws_security_group" "efs" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = merge(

--- a/terraform/modules/ide/scripts/bootstrap.sh
+++ b/terraform/modules/ide/scripts/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 STR=$(cat /etc/os-release)
 SUB="VERSION_ID=\"2\""
 
-marker_file="/var/run/resized.mark"
+marker_file="/root/resized.mark"
 
 if [[ ! -f "$marker_file" ]]; then
   if [ $(readlink -f /dev/xvda) = "/dev/xvda" ]


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the bootstrap process for the Cloud9 instance so that it can run idempotently. This is done by:

1. Changing where the filesystem resize marker file is placed
2. Using the AWS CLI install update flag
3. Removing the CodeCommit SSH key before writing it

There is also a change to add triggers to the invocation Lambda whenever the bootstrap scripts change or a new Cloud9 instance is created.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.