### PR TITLE
Nominate Christina Andonov as maintainer for Automation WG

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -14,19 +14,19 @@ The Steering Committee is a 6 member body, overseeing the governance of the EKS 
 ## Working Groups
 The working groups are led by chairs (6 month terms) and maintainers (6 month terms).
 
-|Working Group|Chair|Maintainer|
+|Working Group|Chair|Maintainers|
 |:----|:-------|:----|
 |Infrastructure|[Niall Thomson](https://github.com/niallthomson)||
 |Fundamentals|[Sai Vennam](https://github.com/svennam92)|[Hemanth AVS](https://github.com/hemanth-avs)|
 |Autoscaling|[Sanjeev Ganjihal](https://github.com/sanjeevrg89)||
-|Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek)|
+|Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov)|
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)||
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)||
 
 ## Wranglers
-Wranglers will work across all topic areas and serve for at least 6 months. 
+Wranglers will work across all topic areas and serve for at least 6 months.
 |Name|Profile|Role|
 |:----|:-------|:----|
 |Math Bruneau|[@ROunofF](https://github.com/ROunofF)|Specialist Solution Architect, Containers|


### PR DESCRIPTION
#### What this PR does / why we need it:

Nominate [Christina Andonov](https://github.com/candonov) as maintainer for Automation WG

Christina Andonov has a wealth of experience and expertise in SRE and DevOps practices. Her current role at AWS focus on driving our DevOps and GitOps PoV in AppMod.
She is an open source maintainer for [Blueprints for Crossplane on Amazon EKS](https://github.com/awslabs/crossplane-on-eks) and [EKS Blueprints for Terraform](https://github.com/aws-ia/terraform-aws-eks-blueprints) projects

Requesting the [steering committee](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/steering.md) to review and [vote](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/model.md#steering-committee) on the nomination.