### PR TITLE
use eks cluster security group for Karpenter

### DIFF
--- a/environment/workspace/modules/autoscaling/compute/karpenter/provisioner/kustomization.yaml
+++ b/environment/workspace/modules/autoscaling/compute/karpenter/provisioner/kustomization.yaml
@@ -20,5 +20,6 @@ replacements:
     fieldPaths:
     - spec.subnetSelector.[karpenter.sh/discovery]
     - spec.securityGroupSelector.[karpenter.sh/discovery]
+    - spec.securityGroupSelector.aws:eks:cluster-name
 resources:
 - provisioner.yaml

--- a/environment/workspace/modules/autoscaling/compute/karpenter/provisioner/provisioner.yaml
+++ b/environment/workspace/modules/autoscaling/compute/karpenter/provisioner/provisioner.yaml
@@ -27,6 +27,6 @@ spec:
   subnetSelector:
     karpenter.sh/discovery: ${EKS_CLUSTER_NAME}
   securityGroupSelector:
-    karpenter.sh/discovery: ${EKS_CLUSTER_NAME}
+    "aws:eks:cluster-name": ${EKS_CLUSTER_NAME}
   tags:
     app.kubernetes.io/created-by: eks-workshop


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow Karpenter nodes to communicate with MNG and Fargate instances by using EKS cluster Security Group

#### Which issue(s) this PR fixes:

Fixes #327

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.