### PR TITLE
adding observability maintainer

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -22,7 +22,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Automation|[Carlos Santana](https://github.com/csantanapr)||
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||
-|Observability|[Nirmal Mehta](https://github.com/normalfaults)||
+|Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)||
 
 ## Wranglers


### PR DESCRIPTION
#### What this PR does / why we need it:
Nominate [Steven David](https://github.com/StevenDavid) as Maintainer for Observability WG. 

Steven supported the creation of the current observability modules, collaborating with working group members to raise the bar on content and supporting the workshop events at reinvent 2022.  

Requesting the [steering committee](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/steering.md) to review and [vote](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/model.md#steering-committee) on the nomination.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.