### PR TITLE
adding security maintainer

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -23,7 +23,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)||
-|Security|[Jimmy Ray](https://github.com/jimmyraywv)||
+|Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
 
 ## Wranglers
 Wranglers will work across all topic areas and serve for at least 6 months. 


### PR DESCRIPTION
#### What this PR does / why we need it:

Nominate [Rodrigo Bersa](https://github.com/rodrigobersa) as Maintainer for Security WG.

Rodrigo will lead the Security Domain for AppMod.

Requesting the [steering committee](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/steering.md) to review and [vote](https://github.com/aws-samples/eks-workshop-v2/blob/main/governance/model.md#steering-committee) on the nomination.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.