### PR TITLE
Fix tag filter for AWS Console link

### DIFF
--- a/website/docs/fundamentals/exposing/loadbalancer/adding-lb.md
+++ b/website/docs/fundamentals/exposing/loadbalancer/adding-lb.md
@@ -115,7 +115,7 @@ The output above shows that we have 3 targets registered to the load balancer us
 
 You can also inspect the NLB in the console by clicking this link:
 
-https://console.aws.amazon.com/ec2/home#LoadBalancers:tag:ingress.k8s.aws/stack=ui/uinlb;sort=loadBalancerName
+https://console.aws.amazon.com/ec2/home#LoadBalancers:tag:service.k8s.aws/stack=ui/ui-nlb;sort=loadBalancerName
 
 Get the URL from the Service resource:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

So users partaking in the workshop can properly view the NLB created during the [Adding LB](https://www.eksworkshop.com/docs/fundamentals/exposing/loadbalancer/adding-lb/) portion

#### Which issue(s) this PR fixes:

Fixes the AWS Console link's filter with an incorrect tag

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.