### PR TITLE
Update adot.md

### DIFF
--- a/website/docs/observability/open-source-metrics/adot.md
+++ b/website/docs/observability/open-source-metrics/adot.md
@@ -44,7 +44,7 @@ $ kubectl apply -k /workspace/modules/observability/oss-metrics/adot
 The specification for the collector is too long to show here, but you can view it like so:
 
 ```bash
-$ kubectl -n other describe opentelemetrycollector adot
+$ kubectl -n other get opentelemetrycollector adot -o yaml
 ```
 
 Let's break this down in to sections to get a better understanding of what has been deployed. This is the OpenTelemetry collector configuration:

--- a/website/docs/observability/open-source-metrics/adot.md
+++ b/website/docs/observability/open-source-metrics/adot.md
@@ -44,7 +44,7 @@ $ kubectl apply -k /workspace/modules/observability/oss-metrics/adot
 The specification for the collector is too long to show here, but you can view it like so:
 
 ```bash
-$ kubectl -n other get opentelemetrycollector adot
+$ kubectl -n other describe opentelemetrycollector adot
 ```
 
 Let's break this down in to sections to get a better understanding of what has been deployed. This is the OpenTelemetry collector configuration:


### PR DESCRIPTION
#### What this PR does / why we need it:

As stated in the sentence before that `The specification for the collector is too long to show here, but you can view it like so:`. 

This is not the case for:
```
kubectl -n other get opentelemetrycollector adot

Output:
NAME   MODE         VERSION   AGE
adot   deployment   0.66.0    4m57s
```

Fixes 
Instead I think `describe` would be the command which provides insightful information

```
kubectl -n other describe opentelemetrycollector adot

Output:                                                                                                                                        
Name:         adot
Namespace:    other
Labels:       app.kubernetes.io/managed-by=opentelemetry-operator
Annotations:  <none>
API Version:  opentelemetry.io/v1alpha1
Kind:         OpenTelemetryCollector
Metadata:

. . . 
```

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.