### PR TITLE
Fix issues with variables in GuardDuty module

### DIFF
--- a/website/docs/security/guardduty/findings/anonymous-user/finding-3.2.md
+++ b/website/docs/security/guardduty/findings/anonymous-user/finding-3.2.md
@@ -24,7 +24,7 @@ Note that the above rolebinding command will trigger `Policy:Kubernetes/Anonymou
 Now let us create a Pod named nginx using a HTTP post call. 
 
 ```bash
-$ APU_URL=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.endpoint" --region $AWS_DEFAULT_REGION --output text)
+$ API_URL=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.endpoint" --region $AWS_DEFAULT_REGION --output text)
 $ curl -k -v $AWS_API/api/v1/namespaces/default/pods -X POST -H 'Content-Type: application/yaml' -d '---
 apiVersion: v1
 kind: Pod

--- a/website/docs/security/guardduty/findings/anonymous-user/finding-3.2.md
+++ b/website/docs/security/guardduty/findings/anonymous-user/finding-3.2.md
@@ -25,7 +25,7 @@ Now let us create a Pod named nginx using a HTTP post call.
 
 ```bash
 $ API_URL=$(aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.endpoint" --region $AWS_DEFAULT_REGION --output text)
-$ curl -k -v $AWS_API/api/v1/namespaces/default/pods -X POST -H 'Content-Type: application/yaml' -d '---
+$ curl -k -v $API_URL/api/v1/namespaces/default/pods -X POST -H 'Content-Type: application/yaml' -d '---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

Users will not be able to push through with the creation of a pod that will trigger the GuardDuty `Impact:Kubernetes/SuccessfulAnonymousAccess` finding because of errors with the variables in the commands. See [this section](https://www.eksworkshop.com/docs/security/guardduty/findings/anonymous-user/finding-3.2).

#### Which issue(s) this PR fixes:

Fixes variable naming and variable usage

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.