### PR TITLE
removed 'deployment/assets' from the kubectl exec command on line 79 as it gives wrong output

### DIFF
--- a/website/docs/fundamentals/storage/efs/deployments.md
+++ b/website/docs/fundamentals/storage/efs/deployments.md
@@ -76,7 +76,7 @@ Now confirm the new product image `newproduct.png` isn't present on the file sys
 
 ```bash
 $ POD_NAME=$(kubectl -n assets get pods -o jsonpath='{.items[1].metadata.name}')
-$ kubectl exec --stdin deployment/assets $POD_NAME \
+$ kubectl exec --stdin $POD_NAME \
   -n assets -- bash -c 'ls /usr/share/nginx/html/assets'
 ```
 


### PR DESCRIPTION
…as it doesn't give the correct/expected output

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.