### PR TITLE
Updated k8s.gcr.io references to registry.k8s.io

### DIFF
--- a/environment/workspace/modules/autoscaling/compute/overprovisioning/setup/deployment-pause.yaml
+++ b/environment/workspace/modules/autoscaling/compute/overprovisioning/setup/deployment-pause.yaml
@@ -16,7 +16,7 @@ spec:
       priorityClassName: pause-pods
       containers:
       - name: reserve-resources
-        image: k8s.gcr.io/pause
+        image: registry.k8s.io/pause
         resources:
           requests:
             memory: "6.5Gi"

--- a/environment/workspace/modules/autoscaling/workloads/cpa/deployment.yaml
+++ b/environment/workspace/modules/autoscaling/workloads/cpa/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: autoscaler
         # HIGHLIGHT
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.5
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
         resources:
             requests:
                 cpu: "20m"

--- a/environment/workspace/modules/networking/prefix/deployment-pause.yaml
+++ b/environment/workspace/modules/networking/prefix/deployment-pause.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
       - name: reserve-resources
-        image: k8s.gcr.io/pause
+        image: registry.k8s.io/pause


### PR DESCRIPTION
#### What this PR does / why we need it:

Updated k8s.gcr.io Container registry references to registry.k8s.io as per https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

#### Which issue(s) this PR fixes:
N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ]  I ran make test or make e2e-test and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.