### PR TITLE
fix: Update sealed secrets deployment to only reference secrets entries

### DIFF
--- a/environment/workspace/modules/security/sealed-secrets/deployment.yaml
+++ b/environment/workspace/modules/security/sealed-secrets/deployment.yaml
@@ -8,19 +8,11 @@ spec:
       containers:
         - name: catalog
           env:
-            - name: DB_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: catalog-sealed-db
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
                   name: catalog-sealed-db
             - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: catalog-sealed-db
-            - name: DB_READ_ENDPOINT
               valueFrom:
                 secretKeyRef:
                   name: catalog-sealed-db


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the Deployment patch in the sealed secrets chapter so that it only references to values stored in the secret, not values that were moved to a ConfigMap.

#### Which issue(s) this PR fixes:

Fixes #332 

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.