### PR TITLE
fix: Spelling mistake related to taints in MNG lab

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
@@ -97,7 +97,7 @@ You can also configure taints on a managed node group using the `eksctl` CLI. Se
 The configuration for managed node groups currently support the folowing values for the taint `effect`:
 * `NO_SCHEDULE` - This corresponds to the Kubernetes `NoSchedule` taint effect. This configures the managed node group with a taint that repels all pods that don't have a matching toleration. All running pods are **not evicted from the manage node group's nodes**.
 * `NO_EXECUTE` - This corresponds to the Kubernetes `NoExecute` taint effect. Allows nodes configured with this taint to not only repel newly scheduled pods but also **evicts any running pods without a matching toleration**.
-* `PREFER_NO_SCHEDULE` - This corresponds to the Kubernets `PreferNoSchedule` taint effect. If possible, EKS avoids scheduling Pods that do not tolerate this taint onto the node.
+* `PREFER_NO_SCHEDULE` - This corresponds to the Kubernetes `PreferNoSchedule` taint effect. If possible, EKS avoids scheduling Pods that do not tolerate this taint onto the node.
 
 We can use the following command to check the taints have been correctly configured for the managed node group:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Addresses spelling error in taints part of MNG lab.

#### Which issue(s) this PR fixes:

Fixes #307 

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.