### PR TITLE
Nominate Umair Ishaq as maintainer for Networking WG

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -21,7 +21,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Autoscaling|[Sanjeev Ganjihal](https://github.com/sanjeevrg89)||
 |Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov)|
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
-|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||[Umair Ishaq](https://github.com/umairishaq)|
+|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)|[Umair Ishaq](https://github.com/umairishaq)|
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
 

--- a/governance/steering.md
+++ b/governance/steering.md
@@ -21,7 +21,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Autoscaling|[Sanjeev Ganjihal](https://github.com/sanjeevrg89)||
 |Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov)|
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
-|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||
+|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||[Umair Ishaq](https://github.com/umairishaq)
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
 

--- a/governance/steering.md
+++ b/governance/steering.md
@@ -21,7 +21,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Autoscaling|[Sanjeev Ganjihal](https://github.com/sanjeevrg89)||
 |Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov)|
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
-|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||[Umair Ishaq](https://github.com/umairishaq)
+|Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||[Umair Ishaq](https://github.com/umairishaq)|
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Umair Ishaq has extensive knowledge of Kubernetes networking and how CNI operates. Umair has been the primary contributor to the current networking chapter and the necessary infrastructure modifications.

Seeking the evaluation and vote of the nomination by the steering committee.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.