### PR TITLE
fix: Test utility should properly handle blocks with no commands

### DIFF
--- a/test/util/src/lib/gatherer/gatherer.ts
+++ b/test/util/src/lib/gatherer/gatherer.ts
@@ -215,7 +215,11 @@ export class Gatherer {
           }
   
           if(add) {
-            data.push(new Script(this.extractCommand(child.value, raw), wait, timeout, hook, hookTimeout, expectError, child.position?.start.line));
+            let command = this.extractCommand(child.value, raw)
+
+            if(command.length > 0) {
+              data.push(new Script(command, wait, timeout, hook, hookTimeout, expectError, child.position?.start.line));
+            }
           }
         }
       }

--- a/test/util/src/lib/markdownsh.ts
+++ b/test/util/src/lib/markdownsh.ts
@@ -189,7 +189,7 @@ class CustomTest extends Test {
               await this.executeShell(testCase.command, testCase.timeout, testCase.expectError)
             }
             catch(e: any) {
-              e.message = `Error running test case command at line ${testCase.lineNumber}`
+              e.message = `Error running test case command at line ${testCase.lineNumber} - ${e.message}`
   
               throw e
             }

--- a/test/util/src/lib/shell/shell.ts
+++ b/test/util/src/lib/shell/shell.ts
@@ -13,6 +13,10 @@ export class ExecutionResult {
 export class DefaultShell implements Shell {
 
   exec(command: string, timeout: number = 300, expect: boolean = false) : Promise<ExecutionResult> {
+    if(!command) {
+      throw new Error("Command should not be empty")
+    }
+
     try {
       const buffer: Buffer = child.execSync(command, {
         timeout: timeout * 1000,

--- a/test/util/test-content/basics/empty.md
+++ b/test/util/test-content/basics/empty.md
@@ -1,0 +1,15 @@
+---
+title: "Scenario - Empty"
+weight: 30
+---
+
+Scenario:
+
+```bash
+# This contains no commands
+```
+
+```bash
+$ ls
+# This contains a command
+```

--- a/test/util/tests/fixtures/basic/a.md
+++ b/test/util/tests/fixtures/basic/a.md
@@ -4,5 +4,5 @@ weight: 20
 ---
 
 ```bash
-dummy
+$ dummy
 ```

--- a/test/util/tests/fixtures/basic/b.md
+++ b/test/util/tests/fixtures/basic/b.md
@@ -4,5 +4,5 @@ weight: 15
 ---
 
 ```bash
-dummy
+$ dummy
 ```

--- a/test/util/tests/fixtures/basic/empty/block.md
+++ b/test/util/tests/fixtures/basic/empty/block.md
@@ -1,0 +1,13 @@
+---
+title: "Empty block"
+weight: 10
+---
+
+```bash
+# No commands here
+```
+
+```bash
+$ ls
+# This has a command
+```

--- a/test/util/tests/fixtures/basic/nested/index.md
+++ b/test/util/tests/fixtures/basic/nested/index.md
@@ -4,5 +4,5 @@ weight: 10
 ---
 
 ```bash
-dummy
+$ dummy
 ```

--- a/test/util/tests/gatherer.test.ts
+++ b/test/util/tests/gatherer.test.ts
@@ -112,6 +112,12 @@ describe('Gatherer', () => {
 
       expect(nestedCategory?.title).to.equal('Nested')
     });
+
+    it('should ignore blocks with no commands', async () => {
+      const emptyBlockPage = result?.children[0].pages[1]
+
+      expect(emptyBlockPage?.scripts.length).to.equal(1)
+    });
   })
   
   after(() => {


### PR DESCRIPTION
#### What this PR does / why we need it:

The test utility currently identifies bash blocks with no commands as having a command thats an empty string, which causes a timeout. This PR ignores these empty blocks when gathering the commands and also includes an additional safeguard to reject empty commands sent to the shell processor.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.