### PR TITLE
chore: Support for TF 1.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: ~1.3.7
+        terraform_version: ~1.4.0
     - name: Verify terraform
       working-directory: terraform
       run: |

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: ~1.3.7
+        terraform_version: ~1.4.0
         terraform_wrapper: false
     - name: Install utilities
       run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: ~1.3.7
+        terraform_version: ~1.4.0
         terraform_wrapper: false
     - name: Install utilities
       run: |

--- a/.github/workflows/test-cleanup.yaml
+++ b/.github/workflows/test-cleanup.yaml
@@ -23,7 +23,7 @@ jobs:
         node-version: '17'
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: ~1.3.7
+        terraform_version: ~1.4.0
     - name: Install utilities
       run: |
         sudo apt install -y gettext

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.3.7"
+  required_version = "> 1.3.7"
 }
 
 provider "aws" {

--- a/terraform/modules/cluster/providers.tf
+++ b/terraform/modules/cluster/providers.tf
@@ -40,5 +40,5 @@ terraform {
       version = ">= 1.7.0"
     }
   }
-  required_version = "~> 1.3.7"
+  required_version = "> 1.3.7"
 }

--- a/terraform/modules/ide/main.tf
+++ b/terraform/modules/ide/main.tf
@@ -7,5 +7,5 @@ terraform {
       version = ">= 4.46.0"
     }
   }
-  required_version = "~> 1.3.7"
+  required_version = "> 1.3.7"
 }

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {}
 
-  required_version = "~> 1.3.7"
+  required_version = "> 1.3.7"
 }
 
 module "core" {


### PR DESCRIPTION
#### What this PR does / why we need it:

Terraform version 1.4 has been released and we currently pin to 1.3.X. This PR relaxes this restriction and upgrades the TF version in all testing workflows.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.