### PR TITLE
Add helm logout for ECR Public helm chart issues (kubecost, karpenter..)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # EKS Workshop - FAQ
 
-### Q: When I create the infrastructure I get an error about the Kubecost helm chart
+### Q: When I create the infrastructure I get an error about some helm charts
 
 The error looks similar to this:
 
@@ -14,7 +14,8 @@ The error looks similar to this:
 ╵
 ```
 
-This is likely due to expired credentials from previously interacting with ECR Public. Run `docker logout` and then re-run `make create-infrastructure`.
+This is likely due to expired credentials from previously interacting with ECR Public. 
+Run `docker logout public.ecr.aws`, `helm registry logout public.ecr.aws` and then re-run `make create-infrastructure`.
 
 ### Q: Destroying my infrastructure failed and now I have AWS resources left over, what can I do?
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Explain how to bypass issues with helm chart using expired credentials for public ECR.

Fixes #

![image](https://user-images.githubusercontent.com/8956643/224990155-efd0a53d-74e4-4344-a04c-00f6a0f5921b.png)

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
