### PR TITLE
Add Sébastien Allamand as maintainer for Automation

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -19,7 +19,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Infrastructure|[Niall Thomson](https://github.com/niallthomson)||
 |Fundamentals|[Sai Vennam](https://github.com/svennam92)|[Hemanth AVS](https://github.com/hemanth-avs)|
 |Autoscaling|[Sanjeev Ganjihal](https://github.com/sanjeevrg89)||
-|Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov)|
+|Automation|[Carlos Santana](https://github.com/csantanapr)|[Tsahi Duek](https://github.com/tsahiduek), [Christina Andonov](https://github.com/candonov), [Sébastien Allamand](https://github.com/allamand)|
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)||
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding Sébastien Allamand as a maintainer for Automation module, Sébastien has contributed to the workshop in many forms from running live workshops, testing, and reviewing PRs.

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
