### PR TITLE
Split commands to improve readability

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/affinity/index.md
+++ b/website/docs/fundamentals/managed-node-groups/affinity/index.md
@@ -39,7 +39,7 @@ fundamentals/affinity/checkout/checkout.yaml
 Deployment/checkout
 ```
 
-To make the change, run the following command to modify the **checkout** deployment in your cluster:
+To make the change, run the following commands to modify the **checkout** deployment in your cluster:
 
 ```bash
 $ kubectl apply -k /workspace/modules/fundamentals/affinity/checkout/
@@ -50,6 +50,8 @@ service/checkout unchanged
 service/checkout-redis unchanged
 deployment.apps/checkout configured
 deployment.apps/checkout-redis unchanged
+```
+```bash
 $ kubectl rollout status deployment/checkout \
   -n checkout --timeout 180s
 ```
@@ -79,7 +81,7 @@ fundamentals/affinity/checkout-redis/checkout-redis.yaml
 Deployment/checkout-redis
 ```
 
-Apply it with the following command:
+Apply it with the following commands:
 
 ```bash
 $ kubectl apply -k /workspace/modules/fundamentals/affinity/checkout-redis/
@@ -90,6 +92,8 @@ service/checkout unchanged
 service/checkout-redis unchanged
 deployment.apps/checkout unchanged
 deployment.apps/checkout-redis configured
+```
+```bash
 $ kubectl rollout status deployment/checkout-redis \
   -n checkout --timeout 180s
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:

Split bash commands to improve readability

#### Which issue(s) this PR fixes:

It's easy to miss `kubectl rollout` command below all the output from `kubectl apply`

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
