### PR TITLE
fix: Remove problematic blueprints addon

### DIFF
--- a/terraform/modules/cluster/addons.tf
+++ b/terraform/modules/cluster/addons.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.16.0//modules/kubernetes-addons"
+  source = "github.com/niallthomson/terraform-aws-eks-blueprints?ref=workshop-fix//modules/kubernetes-addons"
 
   depends_on = [
     aws_eks_addon.vpc_cni


### PR DESCRIPTION
#### What this PR does / why we need it:

A blueprints addon is causing terraform init to fail, this change removes that module.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
