### PR TITLE
Fix number of replicas field 

### DIFF
--- a/website/docs/introduction/kustomize/index.md
+++ b/website/docs/introduction/kustomize/index.md
@@ -11,7 +11,7 @@ For example, take a look at the following manifest file for the `checkout` Deplo
 ../manifests/checkout/deployment.yaml
 ```
 
-This file has already been applied in the previous [Getting Started](../getting-started) lab, but let's say we wanted to scale this component horizontally by updating the `replicas` field using Kustomize. Rather than manually updating this YAML file, we'll use Kustomize to update the `spec/replicas` field from 1 to 2.
+This file has already been applied in the previous [Getting Started](../getting-started) lab, but let's say we wanted to scale this component horizontally by updating the `replicas` field using Kustomize. Rather than manually updating this YAML file, we'll use Kustomize to update the `spec/replicas` field from 1 to 3.
 
 To do so, we'll apply the following kustomization.
 


### PR DESCRIPTION
The kustomize patch updates spec/replicas to 3 replicas. 

apiVersion: apps/v1
kind: Deployment
metadata:
  name: checkout
spec:
  replicas: 3

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
