### PR TITLE
Update statement regarding 3rd checkout replica

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/affinity/index.md
+++ b/website/docs/fundamentals/managed-node-groups/affinity/index.md
@@ -128,7 +128,7 @@ All looks good on the pod scheduling, but we can further verify by scaling the `
 $ kubectl scale --replicas=3 deployment/checkout --namespace checkout
 ```
 
-If we check the running pods we can see that the third `checkout` pod has been placed in a **Pending** state since there are only two nodes and both already have a pod deployed:
+If we check the running pods we can see that the third `checkout` pod has been placed in a Pending state since two of the nodes already have a pod deployed and the third node does not have a `checkout-redis` pod running.
 
 ```bash
 $ kubectl get pods -n checkout


### PR DESCRIPTION
#### What this PR does / why we need it:

In the previous 'Add nodes' section the number of nodes in the managed-ondemand node group was increased from 2 to 3. Events for pending pod: "1 node(s) didn't match pod affinity rules...that the pod didn't tolerate, 2 node(s) didn't match pod anti-affinity rules."


#### Which issue(s) this PR fixes:

So maybe should read something like the following to consider the pod affinity rule as well: 

If we check the running pods we can see that the third checkout pod has been placed in a Pending state since two of the nodes already have a pod deployed and the third node does not have a checkout-redis pod running.

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
