### PR TITLE
Update Fargate CPU/Memory link to use EKS doc

### DIFF
--- a/website/docs/fundamentals/fargate/sizing.md
+++ b/website/docs/fundamentals/fargate/sizing.md
@@ -3,7 +3,7 @@ title: Resource allocation
 sidebar_position: 20
 ---
 
-The primary dimensions of [Fargate pricing](https://aws.amazon.com/fargate/pricing/) is based on CPU and memory, and the amount of resources allocated to a Fargate instance depend on the resource requests specified by the Pod. There is a [documented set](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size) of valid CPU and memory combinations for Fargate that should be considered when assessing if a workload is suitable for Fargate.
+The primary dimensions of [Fargate pricing](https://aws.amazon.com/fargate/pricing/) is based on CPU and memory, and the amount of resources allocated to a Fargate instance depend on the resource requests specified by the Pod. There is a [documented set](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html#fargate-cpu-and-memory) of valid CPU and memory combinations for Fargate that should be considered when assessing if a workload is suitable for Fargate.
 
 We can confirm what resources were provisioned for our Pod from the previous deployment by inspecting its annotations:
 


### PR DESCRIPTION
Update Fargate CPU/Memory link to use EKS doc: https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html#fargate-cpu-and-memory

Was pointing to ECS Fargate docs.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
