### PR TITLE
Add Storage Working Group: Chair - Eric Heinrichs, Maintainer - Andre…

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -24,6 +24,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)|[Umair Ishaq](https://github.com/umairishaq)|
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
 |Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
+|Storage|[Eric Heinrichs](https://github.com/heinrichse)|[Andrew Peng](https://github.com/pengc99)|
 
 ## Wranglers
 Wranglers will work across all topic areas and serve for at least 6 months.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding a new Working Group for Storage. Adding Eric Heinrichs as Chair and nominating Andrew Peng as Maintainer. Andrew is a Storage Solutions Architect with a strong background in containers and Kubernetes. 

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
