### PR TITLE
Move order of Networking modules to prioritize prefix delegation

### DIFF
--- a/website/docs/networking/prefix/index.md
+++ b/website/docs/networking/prefix/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Prefix Delegation"
-sidebar_position: 30
+sidebar_position: 5
 sidebar_custom_props: {"module": true}
 ---
 

--- a/website/docs/networking/security-groups-for-pods/index.md
+++ b/website/docs/networking/security-groups-for-pods/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Security Groups for Pods"
-sidebar_position: 10
+sidebar_position: 30
 weight: 10
 sidebar_custom_props: {"module": true}
 ---


### PR DESCRIPTION
#### What this PR does / why we need it:

Improve UX by having user start with Prefix Delegation to understand VPC CNI before moving to other sections.

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
