### PR TITLE
chore: Pin kubectl version used in netlify

### DIFF
--- a/website/Brewfile.netlify
+++ b/website/Brewfile.netlify
@@ -1,1 +1,0 @@
-brew "kubectl"

--- a/website/netlify-build.sh
+++ b/website/netlify-build.sh
@@ -2,5 +2,13 @@
 
 set -e
 
+wget https://dl.k8s.io/release/v1.23.9/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+
+mkdir ~/bin
+mv ./kubectl ~/bin
+
+export PATH="$PATH:$HOME/bin"
+
 npm install
 npm run build

--- a/website/netlify-build.sh
+++ b/website/netlify-build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-wget https://dl.k8s.io/release/v1.23.9/bin/linux/amd64/kubectl
+wget -q https://dl.k8s.io/release/v1.23.9/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 
 mkdir ~/bin


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the Netlify homebrew integration is used to install kubectl. However, this doesn't let us pin the kubectl to a known compatible version and this has caused issues with the default version moving to 1.27.

This PR pins the version of kubectl by installing the binary directly in the wrapper build script.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
