### PR TITLE
Correct the wrong private subnets value

### DIFF
--- a/website/docs/networking/custom-networking/vpc.md
+++ b/website/docs/networking/custom-networking/vpc.md
@@ -91,4 +91,4 @@ You can view these subnets in the AWS console:
 
 https://console.aws.amazon.com/vpc/home#subnets:tag:created-by=eks-workshop-v2;sort=desc:CidrBlock
 
-Currently our pods are leveraging the private subnets `10.42.0.0/24`, `10.42.1.0/24` and `10.42.2.0/24`. In this lab exercise, we'll move them to consume IP addresses from the `100.64` subnets.
+Currently our pods are leveraging the private subnets `10.42.10.0/24`, `10.42.11.0/24` and `10.42.12.0/24`. In this lab exercise, we'll move them to consume IP addresses from the `100.64` subnets.


### PR DESCRIPTION
#### What this PR does / why we need it:
Correcting the wrong private subnets value on this [content](https://github.com/aws-samples/eks-workshop-v2/blob/main/website/docs/networking/custom-networking/vpc.md).

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
