### PR TITLE
fix: Bump AMI version to 1.23.15

### DIFF
--- a/terraform/modules/cluster/variables.tf
+++ b/terraform/modules/cluster/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_version" {
 variable "ami_release_version" {
   description = "Default EKS AMI release version for node groups"
   type        = string
-  default     = "1.23.9-20221027"
+  default     = "1.23.15-20230203"
 }
 
 variable "map_roles" {


### PR DESCRIPTION
#### What this PR does / why we need it:

We've had several reports of incidents of nodes failing to become healthy with errors like:

```
PLEG is not healthy: pleg was last seen active 41m35.274123984s ago
```

It may be related to this issue since we are using that AMI: https://github.com/awslabs/amazon-eks-ami/issues/1071

This PR bumps the AMI.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
