### PR TITLE
Fixes tip and link in ide.md file

### DIFF
--- a/website/docs/introduction/ide.md
+++ b/website/docs/introduction/ide.md
@@ -18,7 +18,9 @@ There will be a Cloud9 environment named **eks-workshop** available, click the *
 ![Open the Cloud9 IDE](./assets/environment.png)
 
 :::tip
+
 If you do not see the eks-workshop Cloud9 environment this is because it is owned by another IAM user. [Click here](/misc/cloud9-access.md) to see how to resolve the issue.
+
 :::
 
 Once the IDE has loaded, we recommend you use the **+** button and select **New Terminal** to open a new full screen terminal window.


### PR DESCRIPTION
#### What this PR does / why we need it: For some reason the tip Admonition and link to the cloud9 fix is not visible on the website.

#### Which issue(s) this PR fixes: Linking to [cloud9-access.md](https://github.com/aws-samples/eks-workshop-v2/blob/main/website/docs/misc/cloud9-access.md)

Fixes #334

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
