### PR TITLE
Adding verbiage about -f --follow option for logs output

### DIFF
--- a/website/docs/introduction/getting-started/first.md
+++ b/website/docs/introduction/getting-started/first.md
@@ -115,7 +115,9 @@ $ kubectl wait --for=condition=Ready pods --all -n catalog --timeout=180s
 
 Now that the Pods are running we can [check their logs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs), for example the catalog API:
 
-Note:  You can ["follow" the kubectl logs output](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) by using the '-f' option with the command.  (Use CTRL-C to stop following the output)
+:::tip 
+You can ["follow" the kubectl logs output](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) by using the '-f' option with the command.  (Use CTRL-C to stop following the output)
+:::
 
 ```bash
 $ kubectl logs -n catalog deployment/catalog

--- a/website/docs/introduction/getting-started/first.md
+++ b/website/docs/introduction/getting-started/first.md
@@ -115,6 +115,8 @@ $ kubectl wait --for=condition=Ready pods --all -n catalog --timeout=180s
 
 Now that the Pods are running we can [check their logs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs), for example the catalog API:
 
+Note:  You can ["follow" the kubectl logs output](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) by using the '-f' option with the command.  (Use CTRL-C to stop following the output)
+
 ```bash
 $ kubectl logs -n catalog deployment/catalog
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding additional verbiage to provide details of how to use the '-f' option with "kubectl logs" to "follow" the output.

#### Which issue(s) this PR fixes:
This PR does not address an issue - it is an "enhancement"

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
