### PR TITLE
Update documented procedure and results (fundementals/managed-node-groups)

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/index.md
+++ b/website/docs/fundamentals/managed-node-groups/index.md
@@ -38,9 +38,18 @@ $ eksctl get nodegroup --cluster $EKS_CLUSTER_NAME --name $EKS_DEFAULT_MNG_NAME
 ```
 
 There are several attributes of managed node groups that we can see from this output:
-* Nodes are distributed over multiple subnets in various availability zones, providing high availability
 * Configuration of minimum, maximum and desired counts of the number of nodes in this group
 * The instance type for this node group is `m5.large`
 * Uses the `AL2_x86_64` EKS AMI type
+
+
+We can also inspect the nodes and the placement in the availability zones.
+```bash
+
+kubectl get nodes -o wide --label-columns topology.kubernetes.io/zone
+```
+
+You should see:
+* Nodes are distributed over multiple subnets in various availability zones, providing high availability
 
 Over the course of this module we'll make changes to this node group to demonstrate the capabilities of MNGs.

--- a/website/docs/fundamentals/managed-node-groups/index.md
+++ b/website/docs/fundamentals/managed-node-groups/index.md
@@ -44,9 +44,9 @@ There are several attributes of managed node groups that we can see from this ou
 
 
 We can also inspect the nodes and the placement in the availability zones.
-```bash
 
-kubectl get nodes -o wide --label-columns topology.kubernetes.io/zone
+```bash
+$ kubectl get nodes -o wide --label-columns topology.kubernetes.io/zone
 ```
 
 You should see:

--- a/website/docs/introduction/getting-started/first.md
+++ b/website/docs/introduction/getting-started/first.md
@@ -115,6 +115,8 @@ $ kubectl wait --for=condition=Ready pods --all -n catalog --timeout=180s
 
 Now that the Pods are running we can [check their logs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs), for example the catalog API:
 
+Note:  You can ["follow" the kubectl logs output](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) by using the '-f' option with the command.  (Use CTRL-C to stop following the output)
+
 ```bash
 $ kubectl logs -n catalog deployment/catalog
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:
As far as I can deduce, the existing verbiage is inaccurate.  The command identified does not show the availability zones of the nodes.  Happy to be corrected and cancel this PR.

#### Which issue(s) this PR fixes:
N/A

Fixes #
Removed the inaccurate statement that the "availability zones" are present in the eksctl output.
Added another command to provide the currently utilized availability zones for the nodes.

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
