### PR TITLE
Corrected a wrong file path

### DIFF
--- a/website/docs/security/guardduty/findings/finding7.md
+++ b/website/docs/security/guardduty/findings/finding7.md
@@ -24,5 +24,5 @@ Within a few minutes we'll see the finding `Persistence:Kubernetes/ContainerWith
 Cleanup:
 
 ```bash
-$ kubectl delete -f /workspace/modules/security/Guardduty/privileged/mount/privileged-pod-example.yaml
+$ kubectl delete -f /workspace/modules/security/Guardduty/mount/privileged-pod-example.yaml
 ```


### PR DESCRIPTION
The file path to delete the privileged pod example was wrong.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
