### PR TITLE
fix: Upgrade RDS version to 8.0.32

### DIFF
--- a/terraform/modules/cluster/rds.tf
+++ b/terraform/modules/cluster/rds.tf
@@ -9,7 +9,7 @@ module "catalog_mysql" {
 
   # All available versions: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt
   engine               = "mysql"
-  engine_version       = "8.0.27"
+  engine_version       = "8.0.32"
   family               = "mysql8.0" # DB parameter group
   major_engine_version = "8.0"      # DB option group
   instance_class       = "db.t4g.micro"


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrades the version of the RDS database created by the Terraform to 8.0.32

#### Which issue(s) this PR fixes:

Fixes #498 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
