### PR TITLE
Update your-account.md

### DIFF
--- a/website/docs/introduction/setup/your-account.md
+++ b/website/docs/introduction/setup/your-account.md
@@ -69,11 +69,11 @@ $ delete-environment
 ```bash test=false
 # To delete general add-ons, run the following command:
 $ cd terraform
-$ terraform destroy -target=module.cluster.module.eks_blueprints_kubernetes_addons --auto-approve
+$ terraform destroy -target module.cluster.module.eks_blueprints_kubernetes_addons --auto-approve
 # To delete the descheduler add-on, run the following command:
-$ terraform destroy -target=module.cluster.module.descheduler --auto-approve
+$ terraform destroy -target module.cluster.module.descheduler --auto-approve
 # To delete the core blueprints add-ons, run the following command:
-$ terraform destroy -target=module.cluster.module.eks_blueprints --auto-approve
+$ terraform destroy -target module.cluster.module.eks_blueprints --auto-approve
 # To delete the remaining resources created by Terraform, run the following command:
 $ terraform destroy --auto-approve
 ```


### PR DESCRIPTION
Updated commands for destroy module to have a space instead of  =

#### What this PR does / why we need it:
Command had error previously 
#### Which issue(s) this PR fixes:
eks-workshop-v2\terraform> terraform destroy -target=module.cluster.module.eks_blueprints_kubernetes_addons --auto-approve
╷
│ Error: Too many command line arguments
│
│ Expected at most one positional argument.
╵
╷
│ Error: Invalid target "module"
│
│ Prefix "module." must be followed by a module name.
╵

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
