### PR TITLE
Small changes to Observability page 

### DIFF
--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -12,6 +12,15 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 * Control Plane and Pod Logs utilizing Fluentbit
 * Monitoring Metrics with CloudWatch Container Insights
 * Monitoring EKS Metrics with AMP and ADOT.
+<br><br>
+
+
+---
+If you did not a complete the Introduction Session, you can apply this command to our cluster to deploy all of the components:
+```bash wait=10
+$ kubectl apply -k /workspace/manifests
+```
+---
 
 :::info
 To dive deeper into AWS Observability features take a look at the [One Observability Workshop](https://observability.workshop.aws)

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -13,9 +13,11 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 * Monitoring Metrics with CloudWatch Container Insights
 * Monitoring EKS Metrics with AMP and ADOT.
 <br><br>
+ntroduction/getting-started
 
 ---
-If you did not a complete the [Introduction Session](../introduction/getting-started/finish.md), you can apply this command to our cluster to deploy all of the components:
+If you did not a complete the [Introduction Getting Started session](../introduction/getting-started/finish.md), you can run this command to deploy all of the components
+
 ```bash wait=10
 $ kubectl apply -k /workspace/manifests
 ```

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -15,7 +15,7 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 <br><br>
 
 ---
-If you did not a complete the [Introduction Session](../introduction), you can apply this command to our cluster to deploy all of the components:
+If you did not a complete the [Introduction Session](../introduction/getting-started/finish.md), you can apply this command to our cluster to deploy all of the components:
 ```bash wait=10
 $ kubectl apply -k /workspace/manifests
 ```

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -15,7 +15,7 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 <br><br>
 
 ---
-If you did not a complete the [Introduction Session](Introduction), you can apply this command to our cluster to deploy all of the components:
+If you did not a complete the [Introduction Session](../introduction), you can apply this command to our cluster to deploy all of the components:
 ```bash wait=10
 $ kubectl apply -k /workspace/manifests
 ```

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -13,7 +13,6 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 * Monitoring Metrics with CloudWatch Container Insights
 * Monitoring EKS Metrics with AMP and ADOT.
 <br><br>
-ntroduction/getting-started
 
 ---
 If you did not a complete the [Introduction Getting Started session](../introduction/getting-started/finish.md), you can run this command to deploy all of the components

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -14,9 +14,8 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 * Monitoring EKS Metrics with AMP and ADOT.
 <br><br>
 
-
 ---
-If you did not a complete the Introduction Session, you can apply this command to our cluster to deploy all of the components:
+If you did not a complete the [Introduction Session](Introduction), you can apply this command to our cluster to deploy all of the components:
 ```bash wait=10
 $ kubectl apply -k /workspace/manifests
 ```

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -12,7 +12,8 @@ In this chapter,  we'll cover how you can use AWS observability solutions integr
 * Control Plane and Pod Logs utilizing Fluentbit
 * Monitoring Metrics with CloudWatch Container Insights
 * Monitoring EKS Metrics with AMP and ADOT.
-<br><br>
+&nbsp;
+&nbsp;
 
 ---
 If you did not a complete the [Introduction Getting Started session](../introduction/getting-started/finish.md), you can run this command to deploy all of the components


### PR DESCRIPTION
#### What this PR does / why we need it:
Change to Observability page to add a step to deploy modules if the customer did not complete the setup module 

#### Which issue(s) this PR fixes:
Shortcut to deploy all previous modules to allow user to participate it the Observability lab #495

Fixes #
Added a note to the Observability index page to provide instructions to deploy all modules 

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
