### PR TITLE
fix: Add EFS tag resource IAM permission to CSI driver

### DIFF
--- a/terraform/modules/cluster/addons.tf
+++ b/terraform/modules/cluster/addons.tf
@@ -75,6 +75,10 @@ module "eks_blueprints_kubernetes_addons" {
     }]
   }
 
+  aws_efs_csi_driver_irsa_policies = [
+    aws_iam_policy.efs_patch.arn
+  ]
+
   cluster_autoscaler_helm_config = {
     version   = var.helm_chart_versions["cluster_autoscaler"]
     namespace = "kube-system"
@@ -418,7 +422,7 @@ module "eks_blueprints_kubernetes_addons" {
         name  = "applicationSet.tolerations[0].effect"
         value = "NoSchedule"
         type  = "string"
-      }], local.system_component_values)
+    }], local.system_component_values)
   }
 
   tags = local.tags

--- a/terraform/modules/cluster/codecommit.tf
+++ b/terraform/modules/cluster/codecommit.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "gitops_access" {
       "codecommit:GitPull",
       "codecommit:GitPush"
     ]
-    effect    = "Allow"
+    effect = "Allow"
     resources = [
       aws_codecommit_repository.gitops.arn,
       aws_codecommit_repository.argocd.arn

--- a/terraform/modules/cluster/efs.tf
+++ b/terraform/modules/cluster/efs.tf
@@ -47,3 +47,29 @@ resource "aws_efs_mount_target" "efsmtpvsubnet" {
   subnet_id       = local.private_subnet_ids[count.index]
   security_groups = [aws_security_group.efs.id]
 }
+
+resource "aws_iam_policy" "efs_patch" {
+  name        = "${var.environment_name}-efs-tag"
+  path        = "/"
+  description = "Supplemental tag for EFS tag resource"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EFSTagResource",
+      "Effect": "Allow",
+      "Action": "elasticfilesystem:TagResource",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    }
+  ]
+}
+EOF
+  tags   = local.tags
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

EFS has changed the permission model such that the CSI driver requires the `elasticfilesystem:TagResource` IAM permission.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
