### PR TITLE
fix: Managed Node Group lab fixes

### DIFF
--- a/environment/workspace/modules/fundamentals/affinity/checkout/checkout.yaml
+++ b/environment/workspace/modules/fundamentals/affinity/checkout/checkout.yaml
@@ -24,4 +24,8 @@ spec:
                 operator: In
                 values:
                 - service
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - checkout
             topologyKey: kubernetes.io/hostname

--- a/website/docs/fundamentals/managed-node-groups/adding-nodes/index.md
+++ b/website/docs/fundamentals/managed-node-groups/adding-nodes/index.md
@@ -23,7 +23,7 @@ $ eksctl get nodegroup --name $EKS_DEFAULT_MNG_NAME --cluster $EKS_CLUSTER_NAME
 We'll scale the nodegroup in `eks-workshop` by changing the node count from `2` to `3` for **minimum size** and **desired capacity** using below command:
 >Note: You do not need to run below command if you have changed the size of nodegroup using `Amazon EKS Console`.
 
-```bash
+```bash wait=60
 $ eksctl scale nodegroup --name $EKS_DEFAULT_MNG_NAME --cluster $EKS_CLUSTER_NAME --nodes 3 --nodes-min 3 --nodes-max 6
 ```
 
@@ -53,6 +53,6 @@ ip-10-42-12-117.us-west-2.compute.internal   NotReady   <none>   10s   v1.23.9-e
 
 Notice that the node shows a status of `NotReady`, which happens when the new node is still in the process of joining the cluster. We can also use `kubectl wait` to watch until all the nodes report `Ready`:
 
-```bash
+```bash hook=add-node
 $ kubectl wait --for=condition=Ready nodes --all --timeout=300s
 ```

--- a/website/docs/fundamentals/managed-node-groups/adding-nodes/tests/hook-add-node.sh
+++ b/website/docs/fundamentals/managed-node-groups/adding-nodes/tests/hook-add-node.sh
@@ -1,0 +1,17 @@
+set -Eeuo pipefail
+
+before() {
+  echo "noop"
+}
+
+after() {
+  num_nodes=$(kubectl get nodes -l workshop-default=yes -o json | jq -r '.items | length')
+
+  if [[ $num_nodes -lt 3 ]]; then
+    >&2 echo "Nodes did not scale up"
+
+    exit 1
+  fi
+}
+
+"$@"

--- a/website/docs/fundamentals/managed-node-groups/affinity/index.md
+++ b/website/docs/fundamentals/managed-node-groups/affinity/index.md
@@ -42,6 +42,7 @@ Deployment/checkout
 To make the change, run the following command to modify the **checkout** deployment in your cluster:
 
 ```bash
+$ kubectl delete -n checkout deployment checkout
 $ kubectl apply -k /workspace/modules/fundamentals/affinity/checkout/
 namespace/checkout unchanged
 serviceaccount/checkout unchanged
@@ -82,6 +83,7 @@ Deployment/checkout-redis
 Apply it with the following command:
 
 ```bash
+$ kubectl delete -n checkout deployment checkout-redis
 $ kubectl apply -k /workspace/modules/fundamentals/affinity/checkout-redis/
 namespace/checkout unchanged
 serviceaccount/checkout unchanged

--- a/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
@@ -62,7 +62,7 @@ In the next few sections, we'll explore how to add taints to our preconfigured m
 
 Let's start by adding a `taint` to our managed node group using the following `aws` cli command: 
 
-```bash
+```bash timeout=180
 $ aws eks update-nodegroup-config \
     --cluster-name $EKS_CLUSTER_NAME \
     --nodegroup-name $EKS_TAINTED_MNG_NAME \

--- a/website/docs/misc/cloud9-access.md
+++ b/website/docs/misc/cloud9-access.md
@@ -28,8 +28,7 @@ The above arn should be replaced with the arn of the user or role that needs acc
 environment_id_from_arn
 ```
 
-The environment_id_from_arn should be replaced with the environment-id from the arn of the instance you want to manage. 
-The arn can be found by clicking on the instance name.  Everything after the last colon in the arn is the environment-id.
+The `environment_id_from_arn` should be replaced with the `environment-id` from the arn of the instance you want to manage. The arn can be found by clicking on the instance name.  Everything after the last colon in the arn is the `environment-id`.
 
 ![cloud9-arn](./assets/cloud9-arn.png)
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR addresses 3 issues:
1. The affinity lab was showing inconsistent behavior, sometimes failing to schedule pods
2. The tests for "adding nodes" was not properly waiting for nodes to be added
3. The timeout on the tests for adding a taint to the MNG was too low

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
