### PR TITLE
Update deployment-with-efs.md

### DIFF
--- a/website/docs/fundamentals/storage/efs/deployment-with-efs.md
+++ b/website/docs/fundamentals/storage/efs/deployment-with-efs.md
@@ -84,7 +84,7 @@ Now create a new file `newproduct.png` under the assets directory in the first P
 
 ```bash
 $ POD_NAME=$(kubectl -n assets get pods -o jsonpath='{.items[0].metadata.name}')
-$ kubectl exec --stdin deployment/assets $POD_NAME \
+$ kubectl exec --stdin $POD_NAME \
   -n assets -c assets -- bash -c 'touch /usr/share/nginx/html/assets/newproduct.png'
 ```
 
@@ -92,7 +92,7 @@ And verify that the file now also exists in the second Pod:
 
 ```bash
 $ POD_NAME=$(kubectl -n assets get pods -o jsonpath='{.items[1].metadata.name}')
-$ kubectl exec --stdin deployment/assets $POD_NAME \
+$ kubectl exec --stdin $POD_NAME \
   -n assets -c assets -- bash -c 'ls /usr/share/nginx/html/assets'
 chrono_classic.jpg
 gentleman.jpg


### PR DESCRIPTION
Edit to make change to individual pod instead of all pods in deployment.

#### What this PR does / why we need it:
The workshop as written originally deploys newproduct.png to the entire deployment, when the intent of the instruction was to deploy to the first pod only to demonstrate the lack of a shared storage across all of the pods.

This is a continuation of https://github.com/aws-samples/eks-workshop-v2/pull/520

#### Which issue(s) this PR fixes:
https://github.com/aws-samples/eks-workshop-v2/issues/519

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
