### PR TITLE
fix: Limit Terraform AWS provider to < 5.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.46.0"
+      version = ">= 4.46.0, < 5.0.0"
     }
   }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

There are modules leveraged in the Terraform which are not compatible with AWS Terraform Provider >= 5.0 Constraint the version of the provider until these are upgraded.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
