### PR TITLE
Avoid deprecation of vpc attributes error by updating vpc.tf

### DIFF
--- a/terraform/modules/cluster/vpc.tf
+++ b/terraform/modules/cluster/vpc.tf
@@ -11,7 +11,7 @@ locals {
 
 module "aws_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.19.0"
+  version = "5.0.0"
 
   name                  = var.environment_name
   cidr                  = local.vpc_cidr


### PR DESCRIPTION
Updating the version of vpc module to the latest. The old version 3.9.1 is throwing the deprecated error for the below attributes: enable_classiclink
enable_classiclink_dns_support

#### What this PR does / why we need it:
The current repo is trying download the old version of vpc module(3.9.1). It has deprecated attributes that are throwing error.  I updated the version to the latest version 5.0.0 which avoids this issue.

#### Which issue(s) this PR fixes:
https://github.com/aws-samples/eks-workshop-v2/issues/538
Below is the error that will be fixed
```Error: Unsupported argument
│ 
│   on .terraform/modules/cluster.aws_vpc/main.tf line 35, in resource "aws_vpc" "this":
│   35:   enable_classiclink             = null # https://github.com/hashicorp/terraform/issues/31730
│ 
│ An argument named "enable_classiclink" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/cluster.aws_vpc/main.tf line 36, in resource "aws_vpc" "this":
│   36:   enable_classiclink_dns_support = null # https://github.com/hashicorp/terraform/issues/31730
│ 
│ An argument named "enable_classiclink_dns_support" is not expected here.
```

Fixes #
Updated the vpc module version to the latest available(5.0.0)

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
