### PR TITLE
Update Security Working Group - Rodrigo Bersa, Chair

### DIFF
--- a/governance/steering.md
+++ b/governance/steering.md
@@ -23,7 +23,7 @@ The working groups are led by chairs (6 month terms) and maintainers (6 month te
 |Machine Learning|[Masatoshi Hayashi](https://github.com/literalice)||
 |Networking|[Sheetal Joshi](https://github.com/sheetaljoshi)|[Umair Ishaq](https://github.com/umairishaq)|
 |Observability|[Nirmal Mehta](https://github.com/normalfaults)|[Steven David](https://github.com/StevenDavid)|
-|Security|[Jimmy Ray](https://github.com/jimmyraywv)|[Rodrigo Bersa](https://github.com/rodrigobersa)|
+|Security|[Rodrigo Bersa](https://github.com/rodrigobersa)| |
 |Storage|[Eric Heinrichs](https://github.com/heinrichse)|[Andrew Peng](https://github.com/pengc99)|
 
 ## Wranglers


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the Security Working Group chair to Rodrigo Bersa, previously maintainer.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
