### PR TITLE
Update setup.md in website/vpc-lattice

### DIFF
--- a/website/docs/networking/vpc-lattice/setup.md
+++ b/website/docs/networking/vpc-lattice/setup.md
@@ -37,7 +37,7 @@ Create a policy (`recommended-inline-policy.json`) in IAM with the following con
 ```bash
 $ aws iam create-policy \
 --policy-name VPCLatticeControllerIAMPolicy \
---policy-document file://eks-workshop/manifests/modules/networking/vpc-lattice/controller/recommended-inline-policy.json
+--policy-document file://eks-workshop/modules/networking/vpc-lattice/controller/recommended-inline-policy.json
 ```
 
 ```file


### PR DESCRIPTION
Creation of policy points to the wrong location

file://eks-workshop/manifests/modules/networking/vpc-lattice/controller/recommended-inline-policy.json

It should be 

file://eks-workshop/modules/networking/vpc-lattice/controller/recommended-inline-policy.json

#### What this PR does / why we need it:

This PR fixes an issue with a command that includes the wrong path to a policy file. 

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ x ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
