### PR TITLE
Change how tainted node group is created.

### DIFF
--- a/manifests/modules/fundamentals/mng/.workshop/cleanup.sh
+++ b/manifests/modules/fundamentals/mng/.workshop/cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+taint_result=$(aws eks list-nodegroups --cluster-name $EKS_CLUSTER_NAME | { grep taint || true; })
+
+if [ ! -z "$taint_result" ]; then
+  echo "Deleting taint node group..."
+
+  eksctl delete nodegroup taint-mng --cluster $EKS_CLUSTER_NAME --wait > /dev/null
+fi

--- a/manifests/modules/fundamentals/mng/.workshop/terraform/addon.tf
+++ b/manifests/modules/fundamentals/mng/.workshop/terraform/addon.tf
@@ -17,66 +17,10 @@ data "aws_subnets" "private" {
   }
 }
 
-resource "aws_eks_node_group" "tainted" {
-  cluster_name    = local.addon_context.eks_cluster_id
-  node_group_name = "tainted"
-  node_role_arn   = aws_iam_role.tainted_nodegroup.arn
-  subnet_ids      = data.aws_subnets.private.ids
-
-  scaling_config {
-    desired_size = 1
-    max_size     = 2
-    min_size     = 1
-  }
-
-  update_config {
-    max_unavailable = 1
-  }
-
-  labels = {
-    workshop-default = "no"
-    tainted          = "yes"
-  }
-
-  depends_on = [
-    aws_iam_role_policy_attachment.tainted_nodegroup-AmazonEKSWorkerNodePolicy,
-    aws_iam_role_policy_attachment.tainted_nodegroup-AmazonEKS_CNI_Policy,
-    aws_iam_role_policy_attachment.tainted_nodegroup-AmazonEC2ContainerRegistryReadOnly,
-  ]
-}
-
-resource "aws_iam_role" "tainted_nodegroup" {
-  name = "${local.addon_context.eks_cluster_id}-tainted-nodegroup"
-
-  assume_role_policy = jsonencode({
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "ec2.amazonaws.com"
-      }
-    }]
-    Version = "2012-10-17"
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "tainted_nodegroup-AmazonEKSWorkerNodePolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = aws_iam_role.tainted_nodegroup.name
-}
-
-resource "aws_iam_role_policy_attachment" "tainted_nodegroup-AmazonEKS_CNI_Policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = aws_iam_role.tainted_nodegroup.name
-}
-
-resource "aws_iam_role_policy_attachment" "tainted_nodegroup-AmazonEC2ContainerRegistryReadOnly" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = aws_iam_role.tainted_nodegroup.name
-}
-
 output "environment" {
   value = <<EOF
-export EKS_TAINTED_MNG_NAME="${aws_eks_node_group.tainted.node_group_name}"
+%{for index, id in data.aws_subnets.private.ids}
+export PRIMARY_SUBNET_${index + 1}=${id}
+%{endfor}
 EOF
 }

--- a/manifests/modules/fundamentals/mng/taints/nodegroup.yaml
+++ b/manifests/modules/fundamentals/mng/taints/nodegroup.yaml
@@ -1,0 +1,22 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: $EKS_CLUSTER_NAME
+  region: $AWS_REGION
+
+managedNodeGroups:
+  - name: taint-mng
+    instanceTypes:
+    - t3.medium
+    minSize: 1
+    maxSize: 3
+    desiredCapacity: 1
+    labels:
+      workshop-default: 'no'
+      tainted: 'yes'
+    privateNetworking: true
+    subnets:
+    - $PRIMARY_SUBNET_1
+    - $PRIMARY_SUBNET_2
+    - $PRIMARY_SUBNET_3

--- a/website/docs/fundamentals/managed-node-groups/index.md
+++ b/website/docs/fundamentals/managed-node-groups/index.md
@@ -11,11 +11,6 @@ Prepare your environment for this section:
 $ prepare-environment fundamentals/mng
 ```
 
-This will make the following changes to your lab environment:
-- Create an additional managed node group in the Amazon EKS cluster
-
-You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/fundamentals/mng/.workshop/terraform).
-
 :::
 
 In the Getting started lab, we deployed our sample application to EKS and saw the running Pods. But where are these Pods running?

--- a/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
@@ -3,7 +3,15 @@ title: Configuring taints
 sidebar_position: 10
 ---
 
-For the purpose of this exercise we'll provision a separate managed node group which we'll apply taints to. The following command will do this:
+For the purpose of this exercise we'll provision a separate managed node group which we'll apply taints to. 
+
+```file
+manifests/modules/fundamentals/mng/taints/nodegroup.yaml
+```
+
+Note: This configuration file does not yet configure the taints, it only applies a label `tainted: 'yes'`. We will configure the taints on this node group further below.
+
+The following command create this node group:
 
 ```bash timeout=600 hook=configure-taints
 $ cat ~/environment/eks-workshop/modules/fundamentals/mng/taints/nodegroup.yaml | envsubst | eksctl create nodegroup -f -

--- a/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
@@ -11,7 +11,7 @@ manifests/modules/fundamentals/mng/taints/nodegroup.yaml
 
 Note: This configuration file does not yet configure the taints, it only applies a label `tainted: 'yes'`. We will configure the taints on this node group further below.
 
-The following command create this node group:
+The following command creates this node group:
 
 ```bash timeout=600 hook=configure-taints
 $ cat ~/environment/eks-workshop/modules/fundamentals/mng/taints/nodegroup.yaml | envsubst | eksctl create nodegroup -f -

--- a/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/configuring-taints.md
@@ -3,12 +3,10 @@ title: Configuring taints
 sidebar_position: 10
 ---
 
-For the purpose of this exercise we have provisioned a separate managed node group. Check the status of the node group:
+For the purpose of this exercise we'll provision a separate managed node group which we'll apply taints to. The following command will do this:
 
-```bash
-$ eksctl get nodegroup --name $EKS_TAINTED_MNG_NAME --cluster $EKS_CLUSTER_NAME
-CLUSTER       NODEGROUP  STATUS CREATED               MIN SIZE MAX SIZE DESIRED CAPACITY INSTANCE TYPE  IMAGE ID              ASG NAME                                         TYPE
-eks-workshop  tainted    ACTIVE 2022-11-03T14:24:28Z  0        1        1                t3.medium      ami-0b55230f107a87100 eks-tainted-d0c21ef0-8024-f793-52a9-3ed57ca9d457 managed
+```bash timeout=600 hook=configure-taints
+$ cat ~/environment/eks-workshop/modules/fundamentals/mng/taints/nodegroup.yaml | envsubst | eksctl create nodegroup -f -
 ```
 
 It will take *2-3* minutes for the node to join the EKS cluster, until you see this command give the following output:
@@ -16,25 +14,25 @@ It will take *2-3* minutes for the node to join the EKS cluster, until you see t
 ```bash
 $ kubectl get nodes \
     --label-columns eks.amazonaws.com/nodegroup \
-    --selector eks.amazonaws.com/nodegroup=$EKS_TAINTED_MNG_NAME
+    --selector eks.amazonaws.com/nodegroup=taint-mng
 NAME                                         STATUS   ROLES    AGE   VERSION               NODEGROUP
-ip-10-42-12-233.us-west-2.compute.internal   Ready    <none>   63m   vVAR::KUBERNETES_NODE_VERSION   tainted
+ip-10-42-12-233.us-west-2.compute.internal   Ready    <none>   63m   vVAR::KUBERNETES_NODE_VERSION   taint-mng
 ```
 
-The above command makes use of the `--selector` flag to query for all nodes that have a label of `eks.amazonaws.com/nodegroup` that matches the name of our managed node group `$EKS_TAINTED_MNG_NAME`. The `--label-columns` flag also allows us to display the value of the `eks.amazonaws.com/nodegroup` label in the node list. 
+The above command makes use of the `--selector` flag to query for all nodes that have a label of `eks.amazonaws.com/nodegroup` that matches the name of our managed node group `taint-mng`. The `--label-columns` flag also allows us to display the value of the `eks.amazonaws.com/nodegroup` label in the node list. 
 
 Before configuring our taints, let's explore the current configuration of our node. Note that the following command will list the details of all nodes that are part of our managed node group. In our lab, the managed node group has just one instance. 
 
 ```bash
 $ kubectl describe nodes \
-    --selector eks.amazonaws.com/nodegroup=$EKS_TAINTED_MNG_NAME
+    --selector eks.amazonaws.com/nodegroup=taint-mng
 Name:               ip-10-42-12-233.us-west-2.compute.internal
 Roles:              <none>
 Labels:             beta.kubernetes.io/arch=amd64
                     beta.kubernetes.io/instance-type=t3.medium
                     beta.kubernetes.io/os=linux
                     eks.amazonaws.com/capacityType=ON_DEMAND
-                    eks.amazonaws.com/nodegroup=tainted
+                    eks.amazonaws.com/nodegroup=taint-mng
                     eks.amazonaws.com/nodegroup-image=ami-0b55230f107a87100
                     eks.amazonaws.com/sourceLaunchTemplateId=lt-07afc97c4940b6622
                     [...]
@@ -52,14 +50,14 @@ A few things to point out:
 
 While it's easy to taint nodes using the `kubectl` CLI as described [here](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts), an administrator will have to make this change every time the underlying node group scales up or down. To overcome this challenge, AWS supports adding both `labels` and `taints` to managed node groups, ensuring every node within the MNG will have the associated labels and taints configured automatically. 
 
-In the next few sections, we'll explore how to add taints to our preconfigured managed node group `$EKS_TAINTED_MNG_NAME`. 
+In the next few sections, we'll explore how to add taints to our preconfigured managed node group `taint-mng`. 
 
 Let's start by adding a `taint` to our managed node group using the following `aws` cli command: 
 
 ```bash timeout=180
 $ aws eks update-nodegroup-config \
     --cluster-name $EKS_CLUSTER_NAME \
-    --nodegroup-name $EKS_TAINTED_MNG_NAME \
+    --nodegroup-name taint-mng \
     --taints "addOrUpdateTaints=[{key=frontend, value=true, effect=NO_EXECUTE}]"
 {
     "update": {
@@ -77,7 +75,7 @@ $ aws eks update-nodegroup-config \
     }
 }
 $ aws eks wait nodegroup-active --cluster-name $EKS_CLUSTER_NAME \
-  --nodegroup-name $EKS_TAINTED_MNG_NAME
+  --nodegroup-name taint-mng
 ```
 
 The addition, removal, or replacement of taints can be done by using the [`aws eks update-nodegroup-config`](https://docs.aws.amazon.com/cli/latest/reference/eks/update-nodegroup-config.html) CLI command to update the configuration of the managed node group. This can be done by passing either `addOrUpdateTaints` or `removeTaints` and a list of taints to the `--taints` command flag. 
@@ -98,7 +96,7 @@ We can use the following command to check the taints have been correctly configu
 ```bash
 $ aws eks describe-nodegroup \
   --cluster-name $EKS_CLUSTER_NAME \
-  --nodegroup-name $EKS_TAINTED_MNG_NAME \
+  --nodegroup-name taint-mng \
   | jq .nodegroup.taints
 [
   {
@@ -119,6 +117,6 @@ Verifying with the `kubectl` cli command, we can also see that the taint has bee
 
 ```bash
 $ kubectl describe nodes \
-    --selector eks.amazonaws.com/nodegroup=$EKS_TAINTED_MNG_NAME | grep Taints
+    --selector eks.amazonaws.com/nodegroup=taint-mng | grep Taints
 Taints:             frontend=true:NoExecute
 ```

--- a/website/docs/fundamentals/managed-node-groups/taints/implementing-tolerations.md
+++ b/website/docs/fundamentals/managed-node-groups/taints/implementing-tolerations.md
@@ -61,7 +61,7 @@ Waiting for deployment "ui" rollout to finish: 1 old replicas are pending termin
 
 Given the default `RollingUpdate` strategy for our `ui` deployment, the K8s deployment will wait for the newly created pod to be in `Ready` state before terminating the old one. The deployment rollout seems stuck so let's investigate further: 
 
-```bash
+```bash hook=pending-pod
 $ kubectl get pod --namespace ui -l app.kubernetes.io/name=ui
 NAME                  READY   STATUS    RESTARTS   AGE
 ui-659df48c56-z496x   0/1     Pending   0          16s

--- a/website/docs/fundamentals/managed-node-groups/taints/tests/hook-configure-taints.sh
+++ b/website/docs/fundamentals/managed-node-groups/taints/tests/hook-configure-taints.sh
@@ -8,7 +8,7 @@ after() {
   EXIT_CODE=0
 
   timeout -s TERM 180 bash -c \
-    'while [[ $(kubectl get nodes -l eks.amazonaws.com/nodegroup=$EKS_TAINTED_MNG_NAME -o json | jq -r ".items | length") -lt 1 ]];\
+    'while [[ $(kubectl get nodes -l eks.amazonaws.com/nodegroup=taint-mng -o json | jq -r ".items | length") -lt 1 ]];\
     do sleep 10;\
     done' || EXIT_CODE=$?
 

--- a/website/docs/fundamentals/managed-node-groups/taints/tests/hook-pending-pod.sh
+++ b/website/docs/fundamentals/managed-node-groups/taints/tests/hook-pending-pod.sh
@@ -1,0 +1,27 @@
+set -e
+
+before() {
+  echo "noop"
+}
+
+after() {
+  sleep 30
+  EXIT_CODE=0
+
+  timeout -s TERM 180 bash -c \
+    'while [[ $(kubectl get pod -l app.kubernetes.io/instance=ui -n ui -o json | jq -r ".items | length") -lt 2 ]];\
+    do sleep 30;\
+    done' || EXIT_CODE=$?
+
+  if [ $EXIT_CODE -ne 0 ]; then
+    >&2 echo "Pods did not scale within 300 seconds"
+    exit 1
+  fi
+
+  if [[ $(kubectl get pod -l app.kubernetes.io/instance=ui -n ui  --field-selector=status.phase==Pending -o json | jq -r ".items | length") -lt 1 ]]; then
+    echo "There is no pending pod"
+    exit 1
+  fi
+}
+
+"$@"


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the node group for applying taints is provisioned with Terraform. This seems to cause confusion in such an early module as provisioning it this way can take several minutes and is quite variable.

This PR changes this so that the node group is manually provisioned by the user. This makes the process more transparent to the user.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
