### PR TITLE
Change timeout to 100s in chapter "StatefulSet with EBS Volume"

### DIFF
--- a/website/docs/fundamentals/storage/ebs/statefulset-with-ebs.md
+++ b/website/docs/fundamentals/storage/ebs/statefulset-with-ebs.md
@@ -35,7 +35,7 @@ Apply the changes and wait for the new Pods to be rolled out:
 
 ```bash hook=check-pvc
 $ kubectl apply -k ~/environment/eks-workshop/modules/fundamentals/storage/ebs/
-$ kubectl rollout status --timeout=60s statefulset/catalog-mysql-ebs -n catalog
+$ kubectl rollout status --timeout=100s statefulset/catalog-mysql-ebs -n catalog
 ```
 
 Let's now confirm that our newly deployed StatefulSet is running:


### PR DESCRIPTION
#### What this PR does / why we need it:
Current rollout command is  
`kubectl rollout status --timeout=60s statefulset/catalog-mysql-ebs -n catalog`
which will lead to `error: timed out waiting for the condition`. Increase timeout can resolve this issue.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
