### PR TITLE
User now creates Fargate profile

### DIFF
--- a/manifests/modules/fundamentals/fargate/.workshop/cleanup.sh
+++ b/manifests/modules/fundamentals/fargate/.workshop/cleanup.sh
@@ -1,0 +1,7 @@
+check=$(aws eks list-fargate-profiles --cluster-name $EKS_CLUSTER_NAME --query "fargateProfileNames[? @ == 'checkout-profile']" --output text)
+
+if [ ! -z "$check" ]; then
+  echo "Deleting Fargate profile..."
+
+  aws eks delete-fargate-profile --region $AWS_REGION --cluster-name $EKS_CLUSTER_NAME --fargate-profile-name checkout-profile > /dev/null
+fi

--- a/manifests/modules/fundamentals/fargate/.workshop/terraform/addon.tf
+++ b/manifests/modules/fundamentals/fargate/.workshop/terraform/addon.tf
@@ -1,18 +1,3 @@
-resource "aws_eks_fargate_profile" "checkout" {
-  cluster_name           = local.addon_context.eks_cluster_id
-  fargate_profile_name   = "checkout-profile"
-  pod_execution_role_arn = aws_iam_role.fargate.arn
-  subnet_ids             = data.aws_subnets.private.ids
-
-  selector {
-    namespace = "checkout"
-
-    labels = {
-      fargate = "yes"
-    }
-  }
-}
-
 data "aws_vpc" "selected" {
   tags = {
     created-by = "eks-workshop-v2"
@@ -84,4 +69,13 @@ resource "aws_iam_policy" "cwlogs" {
 resource "aws_iam_role_policy_attachment" "cwlogs" {
   policy_arn = aws_iam_policy.cwlogs.arn
   role       = aws_iam_role.fargate.name
+}
+
+output "environment" {
+  value = <<EOF
+export FARGATE_IAM_PROFILE_ARN=${aws_iam_role.fargate.arn}
+%{for index, id in data.aws_subnets.private.ids}
+export PRIVATE_SUBNET_${index + 1}=${id}
+%{endfor}
+EOF
 }

--- a/manifests/modules/fundamentals/fargate/profile/fargate.yaml
+++ b/manifests/modules/fundamentals/fargate/profile/fargate.yaml
@@ -1,0 +1,18 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: $EKS_CLUSTER_NAME
+  region: $AWS_REGION
+
+fargateProfiles:
+- name: checkout-profile
+  selectors:
+  - namespace: checkout
+    labels:
+      fargate: 'yes'
+  subnets:
+  - $PRIVATE_SUBNET_1
+  - $PRIVATE_SUBNET_2
+  - $PRIVATE_SUBNET_3
+  podExecutionRoleARN: $FARGATE_IAM_PROFILE_ARN

--- a/website/docs/fundamentals/fargate/enabling.md
+++ b/website/docs/fundamentals/fargate/enabling.md
@@ -9,77 +9,53 @@ As an administrator, you can use a Fargate profile to declare which Pods run on 
 
 If a Pod matches multiple Fargate profiles, you can specify which profile a Pod uses by adding the following Kubernetes label to the Pod specification: `eks.amazonaws.com/fargate-profile: my-fargate-profile`. The Pod must match a selector in that profile to be scheduled onto Fargate. Kubernetes affinity/anti-affinity rules do not apply and aren't necessary with Amazon EKS Fargate Pods.
 
-A Fargate profile has been pre-configured in your EKS cluster, and you can inspect it:
+Lets start by adding a Fargate profile to our EKS cluster. This is the `eksctl` configuration we'll use: 
+
+```file
+manifests/modules/fundamentals/fargate/profile/fargate.yaml
+```
+
+This configuration creates a Fargate profile called `checkout-profile` with the following characteristics:
+1. Target Pods in the `checkout` namespace that have the label `fargate: yes`
+2. Place pod in the private subnets of the VPC
+3. Apply an IAM role to the Fargate infrastructure so that it can pull images from ECR, write logs to CloudWatch and so on
+
+The following command creates the profile, which will take several minutes:
+
+```bash timeout=600
+$ cat ~/environment/eks-workshop/modules/fundamentals/fargate/profile/fargate.yaml \
+| envsubst \
+| eksctl create fargateprofile -f -
+```
+
+Now we can inspect the Fargate profile:
 
 ```bash
-$ aws eks describe-fargate-profile --cluster-name $EKS_CLUSTER_NAME \
-  --fargate-profile-name checkout-profile
+$ aws eks describe-fargate-profile \
+    --cluster-name $EKS_CLUSTER_NAME \
+    --fargate-profile-name checkout-profile
+{
+    "fargateProfile": {
+        "fargateProfileName": "checkout-profile",
+        "fargateProfileArn": "arn:aws:eks:us-west-2:1234567890:fargateprofile/eks-workshop/checkout-profile/92c4e2e3-50cd-773c-1c32-52e4d44cd0ca",
+        "clusterName": "eks-workshop",
+        "createdAt": "2023-08-05T12:57:58.022000+00:00",
+        "podExecutionRoleArn": "arn:aws:iam::1234567890:role/eks-workshop-fargate",
+        "subnets": [
+            "subnet-01c3614cdd385a93c",
+            "subnet-0e392224ce426565a",
+            "subnet-07f8a6fda62ec83df"
+        ],
+        "selectors": [
+            {
+                "namespace": "checkout",
+                "labels": {
+                    "fargate": "yes"
+                }
+            }
+        ],
+        "status": "ACTIVE",
+        "tags": {}
+    }
+}
 ```
-
-Can you tell what this profile is meant to do? **Hint:** Look at the selectors.
-
-So why isn't the `checkout` service already running on Fargate? Let's check its labels:
-
-```bash
-$ kubectl get pod -n checkout -l app.kubernetes.io/component=service -o json | jq '.items[0].metadata.labels'
-```
-
-Looks like our Pod is missing the label `fargate=yes`, so lets fix that by updating the deployment for that service so the Pod spec includes the label needed for the profile to schedule it on Fargate.
-
-```kustomization
-modules/fundamentals/fargate/enabling/deployment.yaml
-Deployment/checkout
-```
-
-Apply the kustomization to the cluster:
-
-```bash timeout=220 hook=enabling
-$ kubectl apply -k ~/environment/eks-workshop/modules/fundamentals/fargate/enabling
-[...]
-$ kubectl rollout status -n checkout deployment/checkout --timeout=200s
-```
-
-This will cause the Pod specification for the `checkout` service to be updated and trigger a new deployment, replacing all the Pods. When the new Pods are scheduled, the Fargate scheduler will match the new label applied by the kustomization with our target profile and intervene to ensure our Pod is schedule on capacity managed by Fargate.
-
-How can we confirm that it worked? Describe the new Pod thats been created and take a look at the `Events` section:
-
-```bash
-$ kubectl describe pod -n checkout -l fargate=yes
-[...]
-Events:
-  Type     Reason           Age    From               Message
-  ----     ------           ----   ----               -------
-  Warning  LoggingDisabled  10m    fargate-scheduler  Disabled logging because aws-logging configmap was not found. configmap "aws-logging" not found
-  Normal   Scheduled        9m48s  fargate-scheduler  Successfully assigned checkout/checkout-78fbb666b-fftl5 to fargate-ip-10-42-11-96.us-west-2.compute.internal
-  Normal   Pulling          9m48s  kubelet            Pulling image "public.ecr.aws/aws-containers/retail-store-sample-checkout:0.4.0"
-  Normal   Pulled           9m5s   kubelet            Successfully pulled image "public.ecr.aws/aws-containers/retail-store-sample-checkout:0.4.0" in 43.258137629s
-  Normal   Created          9m5s   kubelet            Created container checkout
-  Normal   Started          9m4s   kubelet            Started container checkout
-```
-
-The events from `fargate-scheduler` give us some insight in to what has happened. The entry we're mainly interested in at this stage in the lab is the event with the reason `Scheduled`. Inspecting that closely gives us the name of the Fargate instance that was provisioned for this Pod, in the case of the above example this is `fargate-ip-10-42-11-96.us-west-2.compute.internal`.
-
-We can inspect this node from `kubectl` to get additional information about the compute that was provisioned for this Pod:
-
-```bash
-$ NODE_NAME=$(kubectl get pod -n checkout -l app.kubernetes.io/component=service -o json | jq -r '.items[0].spec.nodeName')
-$ kubectl describe node $NODE_NAME
-Name:               fargate-ip-10-42-11-96.us-west-2.compute.internal
-Roles:              <none>
-Labels:             beta.kubernetes.io/arch=amd64
-                    beta.kubernetes.io/os=linux
-                    eks.amazonaws.com/compute-type=fargate
-                    failure-domain.beta.kubernetes.io/region=us-west-2
-                    failure-domain.beta.kubernetes.io/zone=us-west-2b
-                    kubernetes.io/arch=amd64
-                    kubernetes.io/hostname=ip-10-42-11-96.us-west-2.compute.internal
-                    kubernetes.io/os=linux
-                    topology.kubernetes.io/region=us-west-2
-                    topology.kubernetes.io/zone=us-west-2b
-[...]
-```
-
-This provides us with a number of insights in to the nature of the underlying compute instance:
-- The label `eks.amazonaws.com/compute-type` confirms that a Fargate instance was provisioned
-- Another label `topology.kubernetes.io/zone` specified the availability zone that the pod is running in
-- In the `System Info` section (not shown above) we can see that the instance is running Amazon Linux 2, as well as the version information for system components like `container`, `kubelet` and `kube-proxy`

--- a/website/docs/fundamentals/fargate/index.md
+++ b/website/docs/fundamentals/fargate/index.md
@@ -12,7 +12,7 @@ $ prepare-environment fundamentals/fargate
 ```
 
 This will make the following changes to your lab environment:
-- Create a Fargate profile in the Amazon EKS cluster
+- Create an IAM role to be used by Fargate
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/fundamentals/fargate/.workshop/terraform).
 

--- a/website/docs/fundamentals/fargate/scheduling.md
+++ b/website/docs/fundamentals/fargate/scheduling.md
@@ -1,0 +1,70 @@
+---
+title: Scheduling on Fargate
+sidebar_position: 12
+---
+
+So why isn't the `checkout` service already running on Fargate? Let's check its labels:
+
+```bash
+$ kubectl get pod -n checkout -l app.kubernetes.io/component=service -o json | jq '.items[0].metadata.labels'
+```
+
+Looks like our Pod is missing the label `fargate=yes`, so lets fix that by updating the deployment for that service so the Pod spec includes the label needed for the profile to schedule it on Fargate.
+
+```kustomization
+modules/fundamentals/fargate/enabling/deployment.yaml
+Deployment/checkout
+```
+
+Apply the kustomization to the cluster:
+
+```bash timeout=220 hook=enabling
+$ kubectl apply -k ~/environment/eks-workshop/modules/fundamentals/fargate/enabling
+[...]
+$ kubectl rollout status -n checkout deployment/checkout --timeout=200s
+```
+
+This will cause the Pod specification for the `checkout` service to be updated and trigger a new deployment, replacing all the Pods. When the new Pods are scheduled, the Fargate scheduler will match the new label applied by the kustomization with our target profile and intervene to ensure our Pod is schedule on capacity managed by Fargate.
+
+How can we confirm that it worked? Describe the new Pod thats been created and take a look at the `Events` section:
+
+```bash
+$ kubectl describe pod -n checkout -l fargate=yes
+[...]
+Events:
+  Type     Reason           Age    From               Message
+  ----     ------           ----   ----               -------
+  Warning  LoggingDisabled  10m    fargate-scheduler  Disabled logging because aws-logging configmap was not found. configmap "aws-logging" not found
+  Normal   Scheduled        9m48s  fargate-scheduler  Successfully assigned checkout/checkout-78fbb666b-fftl5 to fargate-ip-10-42-11-96.us-west-2.compute.internal
+  Normal   Pulling          9m48s  kubelet            Pulling image "public.ecr.aws/aws-containers/retail-store-sample-checkout:0.4.0"
+  Normal   Pulled           9m5s   kubelet            Successfully pulled image "public.ecr.aws/aws-containers/retail-store-sample-checkout:0.4.0" in 43.258137629s
+  Normal   Created          9m5s   kubelet            Created container checkout
+  Normal   Started          9m4s   kubelet            Started container checkout
+```
+
+The events from `fargate-scheduler` give us some insight in to what has happened. The entry we're mainly interested in at this stage in the lab is the event with the reason `Scheduled`. Inspecting that closely gives us the name of the Fargate instance that was provisioned for this Pod, in the case of the above example this is `fargate-ip-10-42-11-96.us-west-2.compute.internal`.
+
+We can inspect this node from `kubectl` to get additional information about the compute that was provisioned for this Pod:
+
+```bash
+$ NODE_NAME=$(kubectl get pod -n checkout -l app.kubernetes.io/component=service -o json | jq -r '.items[0].spec.nodeName')
+$ kubectl describe node $NODE_NAME
+Name:               fargate-ip-10-42-11-96.us-west-2.compute.internal
+Roles:              <none>
+Labels:             beta.kubernetes.io/arch=amd64
+                    beta.kubernetes.io/os=linux
+                    eks.amazonaws.com/compute-type=fargate
+                    failure-domain.beta.kubernetes.io/region=us-west-2
+                    failure-domain.beta.kubernetes.io/zone=us-west-2b
+                    kubernetes.io/arch=amd64
+                    kubernetes.io/hostname=ip-10-42-11-96.us-west-2.compute.internal
+                    kubernetes.io/os=linux
+                    topology.kubernetes.io/region=us-west-2
+                    topology.kubernetes.io/zone=us-west-2b
+[...]
+```
+
+This provides us with a number of insights in to the nature of the underlying compute instance:
+- The label `eks.amazonaws.com/compute-type` confirms that a Fargate instance was provisioned
+- Another label `topology.kubernetes.io/zone` specified the availability zone that the pod is running in
+- In the `System Info` section (not shown above) we can see that the instance is running Amazon Linux 2, as well as the version information for system components like `container`, `kubelet` and `kube-proxy`

--- a/website/docs/fundamentals/fargate/tests/hook-enabling.sh
+++ b/website/docs/fundamentals/fargate/tests/hook-enabling.sh
@@ -3,7 +3,12 @@ before() {
 }
 
 after() {
-  kubectl rollout status -n checkout deployment/checkout --timeout=200s
+  check=$(kubectl get po -n checkout -l app.kubernetes.io/instance=checkout,app.kubernetes.io/component=service -o json | jq -r '.items[0].spec.nodeName' | grep 'fargate' || true)
+
+  if [ -z "$check" ]; then
+    echo "checkout pod not scheduled on fargate"
+    exit 1
+  fi
 }
 
 "$@"

--- a/website/docs/fundamentals/fargate/tests/hook-suite.sh
+++ b/website/docs/fundamentals/fargate/tests/hook-suite.sh
@@ -6,6 +6,8 @@ before() {
 
 after() {
   prepare-environment
+
+  aws eks wait fargate-profile-deleted --cluster-name $EKS_CLUSTER_NAME --fargate-profile-name checkout-profile
 }
 
 "$@"


### PR DESCRIPTION
#### What this PR does / why we need it:

Historically the Fargate profile has been created by Terraform. However this causes the prepare environment phase to take longer without user feedback and hides details from the user. This PR changes it so the user creates the Fargate profile themselves.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
