### PR TITLE
Wait for AWS LB controller helm release to install

### DIFF
--- a/manifests/modules/automation/controlplanes/ack/.workshop/terraform/addon.tf
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/terraform/addon.tf
@@ -110,6 +110,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/automation/controlplanes/crossplane/.workshop/terraform/addon.tf
+++ b/manifests/modules/automation/controlplanes/crossplane/.workshop/terraform/addon.tf
@@ -56,6 +56,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/exposing/ingress/.workshop/terraform/addon.tf
+++ b/manifests/modules/exposing/ingress/.workshop/terraform/addon.tf
@@ -3,6 +3,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/exposing/load-balancer/.workshop/terraform/addon.tf
+++ b/manifests/modules/exposing/load-balancer/.workshop/terraform/addon.tf
@@ -3,6 +3,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/observability/kubecost/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/kubecost/.workshop/terraform/addon.tf
@@ -16,6 +16,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
@@ -16,6 +16,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint

--- a/manifests/modules/security/irsa/.workshop/terraform/addon.tf
+++ b/manifests/modules/security/irsa/.workshop/terraform/addon.tf
@@ -3,6 +3,9 @@ module "eks_blueprints_addons" {
   version = "~> 1.0"
 
   enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    wait = true
+  }
 
   cluster_name      = local.addon_context.eks_cluster_id
   cluster_endpoint  = local.addon_context.aws_eks_cluster_endpoint


### PR DESCRIPTION
#### What this PR does / why we need it:

There is an intermittent issue where an lab installs the AWS LB controller in Terraform then immediately attempts to create a load balancer via manifests. This appears to be a race condition due to the helm chart not completing installation.

This PR adds configuration to the LB controller helm chart installs so that it will wait for the chart to install.

#### Which issue(s) this PR fixes:

Fixes #629 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
