### PR TITLE
Ensure kubecost LB is external

### DIFF
--- a/manifests/modules/observability/kubecost/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/kubecost/.workshop/terraform/addon.tf
@@ -41,11 +41,6 @@ module "kubecost" {
 
   helm_config = {
     version = "1.102.0"
-    values = [data.http.kubecost_values.body]
-
-     set = [{
-      name  = "service.type"
-      value = "LoadBalancer"
-    }]
+    values = [data.http.kubecost_values.body, templatefile("${path.module}/values.yaml", {})]
   }
 }

--- a/manifests/modules/observability/kubecost/.workshop/terraform/values.yaml
+++ b/manifests/modules/observability/kubecost/.workshop/terraform/values.yaml
@@ -1,0 +1,5 @@
+service:
+  type: LoadBalancer
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance

--- a/website/docs/observability/kubecost/costallocation.md
+++ b/website/docs/observability/kubecost/costallocation.md
@@ -7,7 +7,7 @@ Now, we'll take a look at Cost Allocation. Click on <b>Cost Allocation</b>.
 
 You should see the following Dashboard:
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/costallocation.png').default}/>
 </browser>
 
@@ -22,13 +22,13 @@ The application we installed in the Introduction section created several of thes
 
 To do this click on the setting button next to <b>Aggregate by</b> at the top right.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/costallocation-filter.png').default}/>
 </browser>
 
 Then under <b>Filters</b> select <b>label</b> from the drop-down menu, enter the value `app.kubernetes.io/created-by: eks-workshop`, and click the plus symbol.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/costallocation-label.png').default}/>
 </browser>
 
@@ -36,13 +36,13 @@ This filters down the namespaces to only show our workloads that have the label 
 
 Now click on <b>Aggregate by</b> and choose <b>Deployment</b>. This will aggregate the costs by deployment instead of by namespace. See below.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/aggregate-by-deployment.png').default}/>
 </browser>
 
 We see that there are different deployments associated with our application. We can dig deeper. Let's look at a single namespace. Set <b>Aggregate by</b> back to <b>Namespace</b>, remove the filter, and click on one of the namespaces in the table. We've chosen the orders namespace.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/namespace.png').default}/>
 </browser>
 
@@ -54,7 +54,7 @@ We can also look at the different resources running in this namespace and see th
 
 Click on one of the entries under <b>Controllers</b>. We've clicked on the orders deployment.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/controllers.png').default}/>
 </browser>
 
@@ -62,7 +62,7 @@ This view shows us more detail of the specific "controller", in this case a depl
 
 Until now we've looked at a broad overview of cost allocations or a deep dive into single resource. What if we want to group dig into cost allocation by team? Consider the following scenario: each team at a company is responsible for their operating costs within a cluster. For example, we have a team that is responsible for all the databases in our cluster and they want to dig into their operating costs. This can be accomplished by giving each database a custom label associated to that team. In our cluster we've done this by given all the database resources the label `app.kubernetes.io/team: database`. Using this label, we can filter on all resources across the different namespaces that belong to this team.
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090/allocations'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090/allocations'>
 <img src={require('./assets/team.png').default}/>
 </browser>
 

--- a/website/docs/observability/kubecost/introduction.md
+++ b/website/docs/observability/kubecost/introduction.md
@@ -17,11 +17,11 @@ Kubecost has been exposed using a `LoadBalancer` service, and we can find the UR
 ```bash
 $ kubectl get service -n kubecost kubecost-cost-analyzer \
     -o jsonpath="{.status.loadBalancer.ingress[*].hostname}:9090{'\n'}"
-a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090
+k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090
 ```
 
 Open this link in your browser to access Kubecost:
 
-<browser url='http://a9e6e1f6b373f44bf8e1c1cb70f6a95b-1567842963.us-west-2.elb.amazonaws.com:9090'>
+<browser url='http://k8s-kubecost-kubecost-e83ecf8fc1-fc26f5c92767520f.elb.us-west-2.amazonaws.com:9090'>
 <img src={require('./assets/overview.png').default}/>
 </browser>

--- a/website/docs/observability/kubecost/tests/hook-kubecost-deployment.sh
+++ b/website/docs/observability/kubecost/tests/hook-kubecost-deployment.sh
@@ -23,11 +23,13 @@ after() {
     exit 1
   fi
 
-    if [[ $prometheus_success != "deployment \"kubecost-prometheus-server\" successfully rolled out" ]]; then
+  if [[ $prometheus_success != "deployment \"kubecost-prometheus-server\" successfully rolled out" ]]; then
     >&2 echo "Prometheus did not rollout"
 
     exit 1
   fi
+
+  wait-for-lb $(kubectl get service -n kubecost kubecost-cost-analyzer -o jsonpath="{.status.loadBalancer.ingress[*].hostname}:9090")
 }
 
 "$@"


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensures the kubecost LB is external-facing and added test to validate this.

#### Which issue(s) this PR fixes:

Fixes #635 

#### Quality checks

- [ ] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
