### PR TITLE
Fix repository ref being passed to CloudFormation deploy instructions

### DIFF
--- a/website/docs/introduction/setup/your-account/index.md
+++ b/website/docs/introduction/setup/your-account/index.md
@@ -30,6 +30,7 @@ Once CloudShell has loaded run the following commands:
 $ wget -q https://raw.githubusercontent.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/VAR::MANIFESTS_REF/lab/cfn/eks-workshop-ide-cfn.yaml -O eks-workshop-ide-cfn.yaml
 $ aws cloudformation deploy --stack-name eks-workshop-ide \
     --template-file ./eks-workshop-ide-cfn.yaml \
+    --parameter-overrides RepositoryRef=VAR::MANIFESTS_REF \
     --capabilities CAPABILITY_NAMED_IAM
 Waiting for changeset to be created..
 Waiting for stack create/update to complete


### PR DESCRIPTION
#### What this PR does / why we need it:

Makes sure the correct repository ref (branch/tag) is passed in when the CloudFormation is used to deploy the lab environment.

#### Which issue(s) this PR fixes:

Fixes #640

#### Quality checks

- [ ] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
