### PR TITLE
Enable IAM Principal AWS Access Console Automatically for C9 Instance…

### DIFF
--- a/manifests/modules/observability/base/.workshop/cleanup.sh
+++ b/manifests/modules/observability/base/.workshop/cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo 'Deleting ClusterRole config'
+if [[ -v C9_USER ]]; then
+    kubectl delete ClusterRoleBinding/eks-console-dashboard-full-access-binding --ignore-not-found=true > /dev/null
+    kubectl wait --for=delete ClusterRoleBinding/eks-console-dashboard-full-access-binding --timeout=60s > /dev/null
+
+    kubectl delete ClusterRole/eks-console-dashboard-full-access-clusterrole --ignore-not-found=true > /dev/null
+    kubectl wait --for=delete ClusterRole/eks-console-dashboard-full-access-clusterrole --timeout=60s > /dev/null
+
+    echo "Deleting IAM user/role from RBAC auth-config2"
+    ACCOUNTID=$(aws sts get-caller-identity | jq -r .Account)
+
+    echo "Removing arn:aws:iam::**:role/${C9_USER} from RBAC"
+    eksctl delete iamidentitymapping --cluster ${EKS_CLUSTER_NAME} --region ${AWS_REGION} --arn arn:aws:iam::${ACCOUNTID}:role/${C9_USER} -d > /dev/null  2>&1
+
+    echo "Removing arn:aws:iam::**:user/${C9_USER} from RBAC"
+    eksctl delete iamidentitymapping --cluster ${EKS_CLUSTER_NAME} --region ${AWS_REGION} --arn arn:aws:iam::${ACCOUNTID}:user/${C9_USER} -d > /dev/null  2>&1
+fi
+
+

--- a/manifests/modules/observability/base/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/base/.workshop/terraform/addon.tf
@@ -1,0 +1,116 @@
+resource "kubernetes_cluster_role" "eks-console-dashboard-full-access-clusterrole" {
+  metadata {
+    name = "eks-console-dashboard-full-access-clusterrole"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["nodes", "namespaces", "pods", "configmaps", "endpoints", "events", "limitranges", "persistentvolumeclaims", "podtemplates", "replicationcontrollers", "resourcequotas", "secrets", "serviceaccounts", "services"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs","cronjobs"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["coordination.k8s.io"]
+    resources  = ["leases"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["discovery.k8s.io"]
+    resources  = ["endpointslices"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["events.k8s.io"]
+    resources  = ["events"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["extensions"]
+    resources  = ["daemonsets", "deployments", "ingresses", "networkpolicies", "replicasets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "networkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["policy"]
+    resources  = ["poddisruptionbudgets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["rolebindings", "roles"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["csistoragecapacities"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+
+resource "kubernetes_cluster_role_binding" "eks-console-dashboard-full-access-binding" {
+  metadata {
+    name = "eks-console-dashboard-full-access-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "eks-console-dashboard-full-access-clusterrole"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "eks-console-dashboard-full-access-group"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+}
+
+data "external" "env" {
+  program = ["${path.module}/env.sh"]
+}
+
+resource "terraform_data" "console-iam-rbac-mapping" {
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Mapping RBAC Permissions"      
+      user_instance=(${data.external.env.result["C9_USER"]})
+      if [[ ! -z "$${user_instance}" ]]; then
+        echo "Mapping user $${user_instance} to RBAC "
+        eksctl create iamidentitymapping --cluster ${local.addon_context.eks_cluster_id} --region ${data.aws_region.current.id} \
+        --arn arn:aws:iam::${local.addon_context.aws_caller_identity_account_id}:user/$${user_instance} --username console-iam-user --group eks-console-dashboard-full-access-group \
+        --no-duplicate-arns -d > /dev/null  2>&1
+
+        eksctl create iamidentitymapping --cluster ${local.addon_context.eks_cluster_id} --region ${data.aws_region.current.id} \
+        --arn arn:aws:iam::${local.addon_context.aws_caller_identity_account_id}:role/$${user_instance} --username console-iam-role --group eks-console-dashboard-full-access-group \
+        --no-duplicate-arns -d > /dev/null  2>&1
+      fi
+
+    EOT
+ }
+}

--- a/manifests/modules/observability/base/.workshop/terraform/env.sh
+++ b/manifests/modules/observability/base/.workshop/terraform/env.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# env.sh
+
+# Change the contents of this output to get the environment variables
+# of interest. The output must be valid JSON, with strings for both
+# keys and values.
+
+cat <<EOF
+{
+  "C9_USER": "$C9_USER",
+  "ASSUME_ROLE": "$ASSUME_ROLE"
+}
+EOF

--- a/website/docs/observability/resource-view/index.md
+++ b/website/docs/observability/resource-view/index.md
@@ -8,13 +8,20 @@ sidebar_custom_props: {"module": true}
 Prepare your environment for this section:
 
 ```bash timeout=300 wait=30
-$ prepare-environment
+$ prepare-environment observability/base
 ```
+
+This will make the following changes to your lab environment:
+- Creates an additional kubernetes ClusterRole with the name "eks-console-dashboard-full-access-clusterrole"
+- Creates a Kubernetes ClusterRoleBinding with the name "eks-console-dashboard-full-access-binding"
+- Mapps the Cloud9 IAM User/ Role to the ClusterRoleBinding ad RBAC group, to grant access the AWS console to view Kubernetes resources.
+
+You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/observability/base/.workshop/terraform).
 
 :::
 
 In this lab, we'll view all Kubernetes API resource types using the AWS Management Console for Amazon EKS. You will be able to view and explore all standard Kubernetes API resource types such as configuration, authorization resources, policy resources, service resources and more. [Kubernetes resource view](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html) is supported for all Kubernetes clusters hosted by Amazon EKS. You can use [Amazon EKS Connector](https://docs.aws.amazon.com/eks/latest/userguide/eks-connector.html) to register and connect any conformant Kubernetes cluster to AWS and visualize it in the Amazon EKS console.
 
-We'll be viewing the resources created by the sample application. Note that you’ll only see resources that you have [RBAC permissions](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html#view-kubernetes-resources-permissions) to access.
+We'll be viewing the resources created by the sample application. Note that you’ll only see resources that you have [RBAC permissions](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html#view-kubernetes-resources-permissions) to access, which were created during the environment preparation. 
 
 ![Insights](/img/resource-view/eks-overview.jpg)


### PR DESCRIPTION
… user.

#### What this PR does / why we need it:
- It creates a ClusterRole and ClusterRoleBinding with Terraform, based on [eks-console-full-access.yaml](https://amazon-eks.s3.us-west-2.amazonaws.com/docs/eks-console-full-access.yaml)
- It mapps the user from the C9_USER env variable from C9 Instance to the ClusterRoleBinding via RBAC

#### Which issue(s) this PR fixes:

Fixes #620 

#### Quality checks

- [x ] My content adheres to the style guidelines
- [ x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
