### PR TITLE
update: Reorder labs in Fundamentals section

### DIFF
--- a/website/docs/fundamentals/exposing/index.md
+++ b/website/docs/fundamentals/exposing/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Exposing applications"
-sidebar_position: 30
+sidebar_position: 10
 ---
 
 Right now our web store application is not exposed to the outside world, so there's no way for users to access it. Although there are many microservices in our web store workload, only the `ui` application needs to be available to end users. This is because the `ui` application will perform all communication to the other backend services using internal Kubernetes networking.

--- a/website/docs/fundamentals/fargate/index.md
+++ b/website/docs/fundamentals/fargate/index.md
@@ -1,6 +1,6 @@
 ---
 title: Fargate
-sidebar_position: 20
+sidebar_position: 40
 sidebar_custom_props: {"module": true}
 ---
 

--- a/website/docs/fundamentals/managed-node-groups/index.md
+++ b/website/docs/fundamentals/managed-node-groups/index.md
@@ -1,6 +1,6 @@
 ---
 title: Managed Node Groups
-sidebar_position: 10
+sidebar_position: 30
 sidebar_custom_props: {"module": true}
 ---
 

--- a/website/docs/fundamentals/storage/index.md
+++ b/website/docs/fundamentals/storage/index.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-sidebar_position: 40
+sidebar_position: 20
 ---
 
 [Storage on EKS](https://docs.aws.amazon.com/eks/latest/userguide/storage.html) will provide a high level overview on how to integrate two AWS Storage services with your EKS cluster.


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR reorders the labs in the Fundamentals section so that it starts with labs that are more development focused. The LB and storage labs are quicker to execute and provide a more immediate accomplishment. There is also commonly a first question after Getting Started about accessing the sample application, which is now the next lab.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
