### PR TITLE
add path statements to patch sections in kustomization files for latest stable of kubectl (1.28.1)

### DIFF
--- a/manifests/modules/automation/gitops/argocd/update-application/kustomization.yaml
+++ b/manifests/modules/automation/gitops/argocd/update-application/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 # HIGHLIGHT
 patches:
 # HIGHLIGHT
-- deployment-patch.yaml
+- path: deployment-patch.yaml

--- a/manifests/modules/autoscaling/compute/karpenter/consolidation/kustomization.yaml
+++ b/manifests/modules/autoscaling/compute/karpenter/consolidation/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../provisioner
 patches:
-- provisioner.yaml
+- path: provisioner.yaml

--- a/manifests/modules/autoscaling/workloads/hpa/kustomization.yaml
+++ b/manifests/modules/autoscaling/workloads/hpa/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 resources:
 - hpa.yaml
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/exposing/load-balancer/ip-mode/kustomization.yaml
+++ b/manifests/modules/exposing/load-balancer/ip-mode/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../nlb
 patches:
-- nlb.yaml
+- path: nlb.yaml

--- a/manifests/modules/fundamentals/affinity/checkout-redis/kustomization.yaml
+++ b/manifests/modules/fundamentals/affinity/checkout-redis/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 bases:
 - ../checkout
 patches:
-- checkout-redis.yaml
-- checkout.yaml
+- path: checkout-redis.yaml
+- path: checkout.yaml

--- a/manifests/modules/fundamentals/affinity/checkout/kustomization.yaml
+++ b/manifests/modules/fundamentals/affinity/checkout/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../../base-application/checkout/
 patches:
-- checkout.yaml
+- path: checkout.yaml

--- a/manifests/modules/fundamentals/fargate/enabling/kustomization.yaml
+++ b/manifests/modules/fundamentals/fargate/enabling/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../../base-application/checkout
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/fundamentals/fargate/scaling/kustomization.yaml
+++ b/manifests/modules/fundamentals/fargate/scaling/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../sizing
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/fundamentals/fargate/sizing/kustomization.yaml
+++ b/manifests/modules/fundamentals/fargate/sizing/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../enabling
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/fundamentals/mng/taints/nodeselector-w-toleration/kustomization.yaml
+++ b/manifests/modules/fundamentals/mng/taints/nodeselector-w-toleration/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../../../base-application/ui
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/fundamentals/mng/taints/nodeselector-wo-toleration/kustomization.yaml
+++ b/manifests/modules/fundamentals/mng/taints/nodeselector-wo-toleration/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../../../base-application/ui
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/fundamentals/storage/efs/deployment/kustomization.yaml
+++ b/manifests/modules/fundamentals/storage/efs/deployment/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 resources:
 - efspvclaim.yaml
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/introduction/kustomize/kustomization.yaml
+++ b/manifests/modules/introduction/kustomize/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../base-application/checkout
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/networking/custom-networking/sampleapp/kustomization.yaml
+++ b/manifests/modules/networking/custom-networking/sampleapp/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../../base-application/checkout/
 patches:
-- checkout.yaml
+- path: checkout.yaml

--- a/manifests/modules/networking/securitygroups-for-pods/rds/kustomization.yaml
+++ b/manifests/modules/networking/securitygroups-for-pods/rds/kustomization.yaml
@@ -22,8 +22,8 @@ vars:
   fieldref:
     fieldpath: data.CATALOG_RDS_PASSWORD
 patches:
-- catalog-configMap.yaml
-- secrets.yaml
+- path: catalog-configMap.yaml
+- path: secrets.yaml
 resources:
 - nlb.yaml
 configurations:

--- a/manifests/modules/security/irsa/service-account/kustomization.yaml
+++ b/manifests/modules/security/irsa/service-account/kustomization.yaml
@@ -15,4 +15,4 @@ vars:
   fieldref:
     fieldpath: data.CARTS_IAM_ROLE
 patches:
-- carts-serviceAccount.yaml
+- path: carts-serviceAccount.yaml

--- a/manifests/modules/security/pss-psa/baseline-namespace/kustomization.yaml
+++ b/manifests/modules/security/pss-psa/baseline-namespace/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 bases:
 - ../base
 patches:
-- namespace.yaml
-- deployment.yaml
+- path: namespace.yaml
+- path: deployment.yaml

--- a/manifests/modules/security/pss-psa/privileged-workload/kustomization.yaml
+++ b/manifests/modules/security/pss-psa/privileged-workload/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../base
 patches:
-- deployment.yaml
+- path: deployment.yaml

--- a/manifests/modules/security/pss-psa/restricted-namespace/kustomization.yaml
+++ b/manifests/modules/security/pss-psa/restricted-namespace/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../base
 patches:
-- namespace.yaml
+- path: namespace.yaml

--- a/manifests/modules/security/pss-psa/restricted-workload/kustomization.yaml
+++ b/manifests/modules/security/pss-psa/restricted-workload/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 bases:
 - ../base
 patches:
-- namespace.yaml
-- deployment.yaml
+- path: namespace.yaml
+- path: deployment.yaml

--- a/manifests/modules/security/sealed-secrets/kustomization.yaml
+++ b/manifests/modules/security/sealed-secrets/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 bases:
 - ../../../base-application/catalog
 patches: 
-- deployment.yaml
+- path: deployment.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:
This is a pr to fix the kubectl / docusaurus errors when running "make serve" with the latest stable version of kubectl (1.28.1)

#### Which issue(s) this PR fixes:
https://github.com/aws-samples/eks-workshop-v2/issues/663

#### Quality checks

- [x ] My content adheres to the style guidelines
- [] I ran `make test` or `make e2e-test` and it was successful
  -  I should add that `make test` is expecting a specific module, and `make e2e-test` is not a valid target in the makefile. However I did test that `make install` and `make serve` work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
