### PR TITLE
Reboot Cloud9 instead of explicitly resizing the partition

### DIFF
--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -285,34 +285,6 @@ Resources:
             runCommand:
             - !Sub |
                 set -e
-      
-                STR=$(cat /etc/os-release)
-                SUB="VERSION_ID=\"2\""
-                
-                marker_file="/root/resized.mark"
-                
-                if [[ ! -f "$marker_file" ]]; then
-                  if [ $(readlink -f /dev/xvda) = "/dev/xvda" ]
-                  then
-                    sudo growpart /dev/xvda 1
-                    if [[ "$STR" == *"$SUB"* ]]
-                    then
-                      sudo xfs_growfs -d /
-                    else
-                      sudo resize2fs /dev/xvda1
-                    fi
-                  else
-                    sudo growpart /dev/nvme0n1 1
-                    if [[ "$STR" == *"$SUB"* ]]
-                    then
-                      sudo xfs_growfs -d /
-                    else
-                      sudo resize2fs /dev/nvme0n1p1
-                    fi
-                  fi
-                fi
-                
-                touch $marker_file
 
                 export AWS_REGION="${AWS::Region}"
                 export REPOSITORY_OWNER="${RepositoryOwner}"
@@ -324,6 +296,10 @@ Resources:
                 curl -fsSL https://raw.githubusercontent.com/${RepositoryOwner}/${RepositoryName}/${RepositoryRef}/lab/scripts/installer.sh | bash
 
                 sudo -E -H -u ec2-user bash -c "curl -fsSL https://raw.githubusercontent.com/${RepositoryOwner}/${RepositoryName}/${RepositoryRef}/lab/scripts/setup.sh | bash"
+
+                echo "Rebooting...."
+
+                FILE=$(mktemp) && echo $FILE && echo '#!/bin/bash' > $FILE && echo 'reboot -f --verbose' >> $FILE && at now + 1 minute -f $FILE
 
   EksWorkshopC9InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
#### What this PR does / why we need it:

The existing CloudFormation for the Cloud9 IDE tries to explicitly grow the disk partition to fill the EBS volume attached to the instance. Change this to instead just reboot the Cloud9 instance after the rest of the bootstrap since this accomplishes the same thing.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
