### PR TITLE
Adding Health Check to catalogue ingress

### DIFF
--- a/manifests/modules/exposing/ingress/multiple-ingress/ingress-catalog.yaml
+++ b/manifests/modules/exposing/ingress/multiple-ingress/ingress-catalog.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/created-by: eks-workshop
   annotations:
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/healthcheck-path: /catalogue
+    alb.ingress.kubernetes.io/healthcheck-path: /health
     # HIGHLIGHT
     alb.ingress.kubernetes.io/group.name: retail-app-group
 spec:

--- a/manifests/modules/exposing/ingress/multiple-ingress/ingress-catalog.yaml
+++ b/manifests/modules/exposing/ingress/multiple-ingress/ingress-catalog.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/created-by: eks-workshop
   annotations:
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /catalogue
     # HIGHLIGHT
     alb.ingress.kubernetes.io/group.name: retail-app-group
 spec:


### PR DESCRIPTION
By default this configuration will make the Target Group for the catalog application unhealthy, although the [ALB documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html) specifies that the traffic will be send if all the targets are unhealthy I think is a better approach to have everything healthy. 

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
