### PR TITLE
Added condition so we don't spam workflow in fork

### DIFF
--- a/.github/workflows/module-test.yaml
+++ b/.github/workflows/module-test.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   run-tests:
+    if: github.repository == 'aws-samples/eks-workshop-v2'
     name: run-tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### What this PR does / why we need it: Added a condition to prevent test workload to run in fork

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
