### PR TITLE
Fix broken linkg in crossplane module

### DIFF
--- a/manifests/modules/automation/controlplanes/crossplane/application/kustomization.yaml
+++ b/manifests/modules/automation/controlplanes/crossplane/application/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../../../base-application/catalog
+- ../../../../../base-application/catalog
 resources:
 - nlb.yaml
 patches:


### PR DESCRIPTION
#### What this PR does / why we need it:
It fixes the broken link in `kustomization.yaml` file in `crossplane/application` module.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test` or `make e2e-test` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
