### PR TITLE
chore: Fixed cleanup of control plane logging lab

### DIFF
--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -116,8 +116,15 @@ if [ ! -z "$REPOSITORY_REF" ]; then
   cat << EOT > /usr/local/bin/reset-environment
 #!/bin/bash
 set -e
-ts=$(date +%s)
-curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1 2>&1 | tee /eks-workshop/logs/action-\$ts.log
+ts=\$(date +%s)
+error=/eks-workshop/logs/action-\$ts.log
+set -o pipefail
+curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1 2>&1 | tee \$error
+if [ \$? -ne 0 ]; then
+  echo "An error occurred, please contact your workshop proctor or raise an issue at https://github.com/aws-samples/eks-workshop-v2/issues"
+  echo "This is the log of that last action: \$error"
+fi
+set +o pipefail
 EOT
   chmod +x /usr/local/bin/reset-environment
   cat << EOT > /usr/local/bin/delete-environment

--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -116,15 +116,7 @@ if [ ! -z "$REPOSITORY_REF" ]; then
   cat << EOT > /usr/local/bin/reset-environment
 #!/bin/bash
 set -e
-ts=\$(date +%s)
-error=/eks-workshop/logs/action-\$ts.log
-set -o pipefail
-curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1 2>&1 | tee \$error
-if [ \$? -ne 0 ]; then
-  echo "An error occurred, please contact your workshop proctor or raise an issue at https://github.com/aws-samples/eks-workshop-v2/issues"
-  echo "This is the log of that last action: \$error"
-fi
-set +o pipefail
+curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1
 EOT
   chmod +x /usr/local/bin/reset-environment
   cat << EOT > /usr/local/bin/delete-environment
@@ -171,6 +163,6 @@ EOT
   chmod +x /usr/local/bin/delete-nodegroup
 fi
 
-mkdir -p /eks-workshop/logs
+mkdir -p /eks-workshop
 
-chown -R ec2-user /eks-workshop
+chown ec2-user /eks-workshop

--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -116,7 +116,8 @@ if [ ! -z "$REPOSITORY_REF" ]; then
   cat << EOT > /usr/local/bin/reset-environment
 #!/bin/bash
 set -e
-curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1
+ts=$(date +%s)
+curl -fsSL https://raw.githubusercontent.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/$REPOSITORY_REF/lab/bin/reset-environment | bash -s -- \$1 2>&1 | tee /eks-workshop/logs/action-\$ts.log
 EOT
   chmod +x /usr/local/bin/reset-environment
   cat << EOT > /usr/local/bin/delete-environment
@@ -163,6 +164,6 @@ EOT
   chmod +x /usr/local/bin/delete-nodegroup
 fi
 
-mkdir -p /eks-workshop
+mkdir -p /eks-workshop/logs
 
-chown ec2-user /eks-workshop
+chown -R ec2-user /eks-workshop

--- a/manifests/modules/observability/logging/cluster/.workshop/cleanup.sh
+++ b/manifests/modules/observability/logging/cluster/.workshop/cleanup.sh
@@ -7,6 +7,6 @@ echo "Disabling EKS control plane logs..."
 aws eks update-cluster-config \
     --region $AWS_REGION \
     --name $EKS_CLUSTER_NAME \
-    --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":false}]}' > /dev/null
+    --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":false}]}' || true > /dev/null
 
 aws eks wait cluster-active --name $EKS_CLUSTER_NAME > /dev/null


### PR DESCRIPTION
#### What this PR does / why we need it: Ignore cleanup error in observability labs, in case logs were never enabled.

#### Which issue(s) this PR fixes:

Fixes #696 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="observability"` and it was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
