### PR TITLE
Pin awscurl and urllib3 versions

### DIFF
--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -44,7 +44,7 @@ download_and_verify () {
 
 yum install --quiet -y findutils jq tar gzip zsh git diffutils wget tree unzip openssl gettext bash-completion python3 pip3 python3-pip amazon-linux-extras
 
-pip3 install awscurl
+pip3 install -q awscurl==0.28 urllib3==1.26.6
 
 # kubectl
 download_and_verify "https://dl.k8s.io/release/v$kubectl_version/bin/linux/amd64/kubectl" "$kubectl_checksum" "kubectl"


### PR DESCRIPTION
#### What this PR does / why we need it:

Running the `awscurl` command in the OSS metrics section gives this error:

```
ValueError: No access key is available
```

Pinning awscurl to version 0.28 resolves this error but gives:

```
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
```

Pinning urllib3 to 1.26.6 resolves this error.

This can be manually resolved with the following command:

```
pip3 install -q awscurl==0.28 urllib3==1.26.6
```

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
