### PR TITLE
Pass test output to test hooks

### DIFF
--- a/test/util/src/lib/shell/shell.ts
+++ b/test/util/src/lib/shell/shell.ts
@@ -3,7 +3,7 @@ import * as child from 'child_process';
 import * as os from 'os';
 
 export interface Shell {
-  exec:(command: string, timeout: number, expect: boolean) => Promise<ExecutionResult>
+  exec:(command: string, timeout: number, expect: boolean, additionalEnv: { [key: string]: string | undefined }) => Promise<ExecutionResult>
 }
 
 export class ExecutionResult {
@@ -19,7 +19,7 @@ export class DefaultShell implements Shell {
 
   constructor(private beforeEach: string) {}
 
-  exec(command: string, timeout: number = 300, expect: boolean = false) : Promise<ExecutionResult> {
+  exec(command: string, timeout: number = 300, expect: boolean = false, additionalEnv: { [key: string]: string | undefined }) : Promise<ExecutionResult> {
     if(!command) {
       throw new Error("Command should not be empty")
     }
@@ -32,7 +32,10 @@ export class DefaultShell implements Shell {
         killSignal: 'SIGKILL',
         stdio: ['inherit', 'pipe', 'pipe'],
         shell: '/bin/bash',
-        env: this.environment
+        env: {
+          ...this.environment,
+          ...additionalEnv
+        }
       });
 
       const output = String(buffer);
@@ -61,7 +64,7 @@ export class DefaultShell implements Shell {
             if(key.startsWith("BASH_FUNC")) {
               processingFunction = true;
             }
-            else {
+            else if(!(key in additionalEnv)) {
               env[key] = val;
             }
           }
@@ -91,7 +94,11 @@ export class DefaultShell implements Shell {
         throw new ShellTimeout(`Timed out after ${timeout} seconds`, e.stdout, e.stderr, timeout)
       }
 
-      throw new ShellError(e.status, e.message, e.stdout, e.stderr)
+      if(!expect) {
+        throw new ShellError(e.status, e.message, e.stdout, e.stderr)
+      }
+
+      return Promise.resolve(new ExecutionResult(e.stderr));
     }
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR provides an environment variable called `TEST_OUTPUT` to test hooks so that they can easily perform assertions on the output of the script in the `bash` block. It also adds corresponding documentation to the test util.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
