### PR TITLE
Fix the terraform destroy command

### DIFF
--- a/website/docs/introduction/setup/your-account/using-terraform.md
+++ b/website/docs/introduction/setup/your-account/using-terraform.md
@@ -84,5 +84,5 @@ Next delete the cluster with `terraform`:
 
 ```bash
 $ cd ~/environment/terraform
-$ terraform -var="cluster_name=$EKS_CLUSTER_NAME" -auto-approve
+$ terraform destroy -var="cluster_name=$EKS_CLUSTER_NAME" -auto-approve
 ```


### PR DESCRIPTION
The Terraform page's example command for cleaning up did not include the `destroy` verb. Without it Terraform proceeds to destroy exactly nothing.

#### What this PR does / why we need it:
It corrects the workshop tutorial

#### Which issue(s) this PR fixes:
I did not raise an issue for this one

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
