### PR TITLE
Fixing time out issue during test

### DIFF
--- a/website/docs/aiml/inferentia/compile.md
+++ b/website/docs/aiml/inferentia/compile.md
@@ -25,11 +25,11 @@ This lab uses DLC to compile the model on EKS. Create the Pod by running the fol
 
 ```bash timeout=600
 $ kubectl apply -k ~/environment/eks-workshop/modules/aiml/inferentia/compiler/
-$ kubectl -n aiml wait --for=condition=Ready --timeout=7m pod/compiler
+$ kubectl -n aiml wait --for=condition=Ready --timeout=10m pod/compiler
 ```
 
 :::note
-This command can take up to 7 min.
+This command can take up to 10 min.
 :::
 
 Next, copy the code for compiling a model on to the pod and run it:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a time out issue during the AI/ML module test.

#### Which issue(s) this PR fixes:
Time out issue during the model creation section in AIML Compile a pre-trained model for AWS Inferentia.

Fixes #
https://github.com/aws-samples/eks-workshop-v2/actions/runs/6716768282/job/18253501394#step:8:34

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
