### PR TITLE
fix: Formating in Pod Security Standards introduction

### DIFF
--- a/website/docs/security/pod-security-standards/index.md
+++ b/website/docs/security/pod-security-standards/index.md
@@ -25,7 +25,7 @@ The policy levels are defined as:
 
 * **Privileged:** Unrestricted (unsecure) policy, providing the widest possible level of permissions. This policy allows for known privilege escalations. It's the absence of a policy. This is good for applications such as logging agents, CNIs, storage drivers, and other system wide applications that need privileged access.
 * **Baseline:** Minimally restrictive policy which prevents known privilege escalations. Allows the default (minimally specified) Pod configuration. The baseline policy prohibits use of hostNetwork, hostPID, hostIPC, hostPath, hostPort, the inability to add Linux capabilities, along with several other restrictions. 
-* **Restricted:*** Heavily restricted policy, following current Pod hardening best practices. This policy inherits from the baseline and adds further restrictions such as the inability to run as root or a root-group. Restricted policies may impact an application's ability to function. They are primarily targeted at running security critical applications.
+* **Restricted:** Heavily restricted policy, following current Pod hardening best practices. This policy inherits from the baseline and adds further restrictions such as the inability to run as root or a root-group. Restricted policies may impact an application's ability to function. They are primarily targeted at running security critical applications.
 
 The PSA admission controller implements the controls, outlined by the PSS policies, via three modes of operation, listed below.
 


### PR DESCRIPTION
Removing additional start symbol which seems like a typo for bold text.
