### PR TITLE
Fix for loop when instance isn't running yet

### DIFF
--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -223,8 +223,9 @@ Resources:
                       print('Instance is currently in state'.format(instance_state))
                       while instance_state != 'running':
                           time.sleep(5)
-                          instance_state = ec2.describe_instances(InstanceIds=[instance_id])
-                          print('Waiting for instance in state {}'.format(instance_state))
+                          di = ec2.describe_instances(InstanceIds=[instance_id])
+                          instance_state = di['Reservations'][0]['Instances'][0]['State']['Name']
+                          print('Waiting for instance in state: {}'.format(instance_state))
 
                       print('Instance is ready')
 


### PR DESCRIPTION
#### What this PR does / why we need it: Fix for a broken loop when instance isn't running just yet

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
