### PR TITLE
Update custom networking lab: provision new node group 

### DIFF
--- a/website/docs/networking/vpc-cni/custom-networking/provision-new-node-group.md
+++ b/website/docs/networking/vpc-cni/custom-networking/provision-new-node-group.md
@@ -10,7 +10,7 @@ $ aws eks create-nodegroup --region $AWS_REGION \
   --cluster-name $EKS_CLUSTER_NAME \
   --nodegroup-name custom-networking \
   --instance-types t3.medium --node-role $CUSTOM_NETWORKING_NODE_ROLE \
-  --subnets $PRIMARY_SUBNET_1 $PRIMARY_SUBNET_2 $PRIMARY_SUBNET_3 \
+  --subnets $SECONDARY_SUBNET_1 $SECONDARY_SUBNET_2 $SECONDARY_SUBNET_3 \
   --labels type=customnetworking \
   --scaling-config minSize=1,maxSize=1,desiredSize=1
 ```
@@ -27,7 +27,7 @@ Once this is complete we can see the new nodes registered in the EKS cluster:
 $ kubectl get nodes -L eks.amazonaws.com/nodegroup
 NAME                                            STATUS   ROLES    AGE   VERSION               NODEGROUP
 ip-10-42-104-242.us-west-2.compute.internal     Ready    <none>   84m   vVAR::KUBERNETES_NODE_VERSION   default
-ip-10-42-110-28.us-west-2.compute.internal      Ready    <none>   61s   vVAR::KUBERNETES_NODE_VERSION   custom-networking
+ip-100-64-14-49.us-west-2.compute.internal      Ready    <none>   61s   vVAR::KUBERNETES_NODE_VERSION   custom-networking
 ip-10-42-139-60.us-west-2.compute.internal      Ready    <none>   65m   vVAR::KUBERNETES_NODE_VERSION   default
 ip-10-42-180-105.us-west-2.compute.internal     Ready    <none>   65m   vVAR::KUBERNETES_NODE_VERSION   default
 ```


### PR DESCRIPTION
For custom networking group we need to use SECONDARY SUBNETS.

#### What this PR does / why we need it: In this lab example, we need to create custom-networking group to use the SECONDARY subnets. But in the example mentioned it was using PRIMARY Subnets which is not correct.

#### Which issue(s) this PR fixes: fix the correct subnets for custom-networking nodegroups

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
