### PR TITLE
chore: Source kubectl version from shared script

### DIFF
--- a/.github/workflows/website-build.yaml
+++ b/.github/workflows/website-build.yaml
@@ -13,9 +13,14 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+    - name: Get kubectl version
+      run: |
+        source hack/lib/kubectl-version.sh
+        echo "Using kubectl ${KUBECTL_VERSION}"
+        echo "KUBECTL_VERSION=$KUBECTL_VERSION" >> $GITHUB_ENV
     - uses: azure/setup-kubectl@v3
       with:
-        version: 'v1.27.7'
+        version: '${{ env.KUBECTL_VERSION }}'
       id: install
     - name: Run website build
       working-directory: website

--- a/hack/lib/kubectl-version.sh
+++ b/hack/lib/kubectl-version.sh
@@ -1,0 +1,1 @@
+export KUBECTL_VERSION='v1.27.7'

--- a/website/netlify-build.sh
+++ b/website/netlify-build.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-wget -q https://dl.k8s.io/release/v1.27.7/bin/linux/amd64/kubectl
+source ../hack/lib/kubectl-version.sh
+
+wget -q https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 
 mkdir ~/bin


### PR DESCRIPTION
#### What this PR does / why we need it:

Makes updating the version of kubectl in multiple places slightly easier.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
