### PR TITLE
update: eks-workshop-ide-cfn.yaml managed role too permissive

### DIFF
--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -81,6 +81,7 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AWSCloud9Administrator
+      - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: "/"
 

--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -82,8 +82,18 @@ Resources:
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AWSCloud9Administrator
       - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+      - arn:aws:iam::aws:policy/AmazonEC2FullAccess
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - arn:aws:iam::aws:policy/IAMFullAccess
       Path: "/"
+      Policies:
+      - PolicyName: EksWorkshopC9EKSPermissions
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: eks:*
+            Resource: '*'
 
   EksWorkshopC9LambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -80,7 +80,7 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/AWSCloud9Administrator
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: "/"
 


### PR DESCRIPTION
The admin managed policy is blocked by most organizations. I believe the AWSCloud9Administrator will allow the lab to work the same without conflicting with org SCPs

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes # None 

#### Quality checks

- [x ] My content adheres to the style guidelines
- [x ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
