### PR TITLE
chore: Update Lambda runtime for Cloud9 CloudFormation

### DIFF
--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -167,7 +167,7 @@ Resources:
         Fn::GetAtt:
         - EksWorkshopC9LambdaExecutionRole
         - Arn
-      Runtime: python3.9
+      Runtime: python3.12
       Environment:
         Variables:
           DiskSize:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update Lambda runtime for Cloud9 customization. To be honest, I guessed 3.9 deprecated soon, but it's not, it's 3.8 :)
Nevermind, I've executed the creation of the ide environment and it works without any code modification.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
