### PR TITLE
fix: Set EKS cluster name in Terraform self-service instructions

### DIFF
--- a/website/docs/introduction/setup/your-account/using-terraform.md
+++ b/website/docs/introduction/setup/your-account/using-terraform.md
@@ -52,6 +52,7 @@ $ curl --remote-name-all https://raw.githubusercontent.com/VAR::MANIFESTS_OWNER/
 Run the following Terraform commands to deploy your workshop environment.
 
 ```bash
+$ export EKS_CLUSTER_NAME=eks-workshop
 $ terraform init
 $ terraform apply -var="cluster_name=$EKS_CLUSTER_NAME" -auto-approve
 ```


### PR DESCRIPTION
export EKS_CLUSTER_NAME

#### What this PR does / why we need it:
Add the required step to define EKS_CLUSTER_NAME.
#### Which issue(s) this PR fixes:
Missing variable definition for EKS_CLUSTER_NAME.
Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
