### PR TITLE
Additional instructions for prepare-environment command errors

### DIFF
--- a/website/docs/observability/resource-view/index.md
+++ b/website/docs/observability/resource-view/index.md
@@ -13,6 +13,8 @@ Prepare your environment for this section:
 $ prepare-environment
 ```
 
+If you encounter an error when running the `prepare-environment` command, run this command first `kubectl config use-context eks-workshop`. Then rerun the `prepare-environment` command.
+
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/observability/base/.workshop/terraform).
 
 :::


### PR DESCRIPTION
#### What this PR does / why we need it:
The prepare-environment command errors out and requires additional use-context commands for it to start working.

#### Which issue(s) this PR fixes:

Fixes # No issue logged for this one yet

#### Quality checks

- [ x ] My content adheres to the style guidelines
- [ x ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
