### PR TITLE
feat: Analytics for AWS events

### DIFF
--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -67,6 +67,11 @@ fi
 ln -s $manifests_path /home/ec2-user/environment/eks-workshop
 
 if [ ! -z "$module" ]; then
+  if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
+    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+    curl --get --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
+  fi
+
   if [ $module = "introduction/getting-started" ]; then
     exit
   fi

--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -67,6 +67,8 @@ fi
 ln -s $manifests_path /home/ec2-user/environment/eks-workshop
 
 if [ ! -z "$module" ]; then
+  ANALYTICS_ENDPOINT=${ANALYTICS_ENDPOINT:-""}
+
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
     curl --get -s --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true

--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -69,7 +69,7 @@ ln -s $manifests_path /home/ec2-user/environment/eks-workshop
 if [ ! -z "$module" ]; then
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
-    curl --get --quiet --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
+    curl --get -s --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
   fi
 
   if [ $module = "introduction/getting-started" ]; then

--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -69,7 +69,7 @@ ln -s $manifests_path /home/ec2-user/environment/eks-workshop
 if [ ! -z "$module" ]; then
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
-    curl --get --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
+    curl --get --quiet --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
   fi
 
   if [ $module = "introduction/getting-started" ]; then

--- a/lab/cfn/eks-workshop-ide-cfn.yaml
+++ b/lab/cfn/eks-workshop-ide-cfn.yaml
@@ -59,6 +59,10 @@ Parameters:
     Type: String
     Description: Triggers the Cloud9 to update itself
     Default: "0"
+  AnalyticsEndpoint:
+    Type: String
+    Description: Analytics endpoint used for AWS events
+    Default: ""
 
 Conditions: 
   Create3rdPartyResources: !Equals [ !Ref EksWorkshopC9EnvType, 3rdParty ]
@@ -362,6 +366,7 @@ Resources:
                 export REPOSITORY_REF="${RepositoryRef}"
                 export CLOUD9_ENVIRONMENT_ID="${EksWorkshopC9Instance}"
                 export RESOURCES_PRECREATED="${ResourcesPrecreated}"
+                export ANALYTICS_ENDPOINT="${AnalyticsEndpoint}"
 
                 curl -fsSL https://raw.githubusercontent.com/${RepositoryOwner}/${RepositoryName}/${RepositoryRef}/lab/scripts/installer.sh | bash
 

--- a/lab/scripts/setup.sh
+++ b/lab/scripts/setup.sh
@@ -47,4 +47,6 @@ RESOURCES_PRECREATED=${RESOURCES_PRECREATED:-"false"}
 
 echo "export RESOURCES_PRECREATED='${RESOURCES_PRECREATED}'" > ~/.bashrc.d/infra.bash
 
+echo "export ANALYTICS_ENDPOINT='${ANALYTICS_ENDPOINT}'" > ~/.bashrc.d/analytics.bash
+
 /usr/local/bin/kubectl completion bash >>  ~/.bashrc.d/kubectl_completion.bash


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the ability to enable analytics on labs run by participants. This feature is not enabled by default and not used when running the workshop in your own AWS account. It is intended only for when the workshop is run at AWS events in accounts provided by AWS.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
