### PR TITLE
[FIX] Update ADOT version, fix VPC Lattice module cleanup, karpenter test

### DIFF
--- a/manifests/modules/networking/vpc-lattice/.workshop/cleanup.sh
+++ b/manifests/modules/networking/vpc-lattice/.workshop/cleanup.sh
@@ -6,11 +6,11 @@ logmessage "Deleting VPC Lattice routes and gateway..."
 
 kubectl delete namespace checkoutv2 --ignore-not-found
 
-delete-all-if-crd-exists targetgrouppolicies.application-networking.k8s.aws
-
 kubectl delete -f ~/environment/eks-workshop/modules/networking/vpc-lattice/routes --ignore-not-found
 cat ~/environment/eks-workshop/modules/networking/vpc-lattice/controller/eks-workshop-gw.yaml | envsubst | kubectl delete --ignore-not-found -f -
 kubectl delete -f ~/environment/eks-workshop/modules/networking/vpc-lattice/controller/gatewayclass.yaml --ignore-not-found
+
+delete-all-if-crd-exists targetgrouppolicies.application-networking.k8s.aws
 
 logmessage "Waiting for VPC Lattice target groups to be deleted..."
 

--- a/manifests/modules/observability/container-insights/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/container-insights/.workshop/terraform/addon.tf
@@ -3,7 +3,7 @@ module "adot-operator" {
 
   addon_config = {
     kubernetes_version = local.eks_cluster_version
-    addon_version      = "v0.78.0-eksbuild.2"
+    addon_version      = "v0.92.1-eksbuild.1"
     most_recent        = false
     
     preserve           = false

--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
@@ -44,7 +44,7 @@ module "adot-operator" {
 
   addon_config = {
     kubernetes_version = local.eks_cluster_version
-    addon_version      = "v0.78.0-eksbuild.2"
+    addon_version      = "v0.92.1-eksbuild.2"
     most_recent        = false
     
     preserve           = false

--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/addon.tf
@@ -44,7 +44,7 @@ module "adot-operator" {
 
   addon_config = {
     kubernetes_version = local.eks_cluster_version
-    addon_version      = "v0.92.1-eksbuild.2"
+    addon_version      = "v0.92.1-eksbuild.1"
     most_recent        = false
     
     preserve           = false

--- a/website/docs/autoscaling/compute/karpenter/node-provisioning.md
+++ b/website/docs/autoscaling/compute/karpenter/node-provisioning.md
@@ -48,13 +48,13 @@ Before we proceed, what instance from the table above do you think Karpenter wil
 
 Scale the deployment:
 
-```bash hook=karpenter-deployment
+```bash
 $ kubectl scale -n other deployment/inflate --replicas 5
 ```
 
 Because this operation is creating one or more new EC2 instances it will take a while, you can use `kubectl` to wait until its done with this command:
 
-```bash
+```bash hook=karpenter-deployment
 $ kubectl rollout status -n other deployment/inflate --timeout=180s
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it: 
- Fix ADOT Version so it's support 1.29
- Fix VPC Lattice cleanup to delete CRD after the resources
- Move the karpenter wait hook on the rollout command

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
