### PR TITLE
Disclaimer when setting up using Cloud9

### DIFF
--- a/website/docs/introduction/setup/your-account/using-eksctl.md
+++ b/website/docs/introduction/setup/your-account/using-eksctl.md
@@ -3,6 +3,7 @@ title: Using eksctl
 sidebar_position: 20
 ---
 ::: Note when using Cloud9
+
 Cloud9 normally manages IAM credentials dynamically. This isn’t currently compatible with the EKS IAM authentication. Make sure to disable it and rely on the IAM role instead of the Cloud9 instance.
 :::
 

--- a/website/docs/introduction/setup/your-account/using-eksctl.md
+++ b/website/docs/introduction/setup/your-account/using-eksctl.md
@@ -2,7 +2,7 @@
 title: Using eksctl
 sidebar_position: 20
 ---
-::: Note when using Cloud9
+:::tip Note when using Cloud9
 
 Cloud9 normally manages IAM credentials dynamically. This isn’t currently compatible with the EKS IAM authentication. Make sure to disable it and rely on the IAM role instead of the Cloud9 instance.
 :::

--- a/website/docs/introduction/setup/your-account/using-eksctl.md
+++ b/website/docs/introduction/setup/your-account/using-eksctl.md
@@ -2,6 +2,9 @@
 title: Using eksctl
 sidebar_position: 20
 ---
+::: Note when using Cloud9
+Cloud9 normally manages IAM credentials dynamically. This isn’t currently compatible with the EKS IAM authentication. Make sure to disable it and rely on the IAM role instead of the Cloud9 instance.
+:::
 
 This section outlines how to build a cluster for the lab exercises using the [eksctl tool](https://eksctl.io/). This is the easiest way to get started, and is recommended for most learners.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
When users are setting up their clusters using eksctl from Cloud9, it is possible that temporary credentials are set in their environment which affects the usage of the cluster after creation.

#### Which issue(s) this PR fixes:
NA

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
