### PR TITLE
update: Use AWS CLI for Graviton nodes instead of eksctl

### DIFF
--- a/manifests/modules/fundamentals/mng/graviton/.workshop/cleanup.sh
+++ b/manifests/modules/fundamentals/mng/graviton/.workshop/cleanup.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-delete-nodegroup graviton yes
+delete-nodegroup graviton

--- a/manifests/modules/fundamentals/mng/graviton/.workshop/terraform/addon.tf
+++ b/manifests/modules/fundamentals/mng/graviton/.workshop/terraform/addon.tf
@@ -10,8 +10,36 @@ data "aws_subnets" "private" {
   }
 }
 
+resource "aws_iam_role" "graviton_node" {
+  name = "${local.addon_context.eks_cluster_id}-graviton-node"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  managed_policy_arns = [
+    "arn:${local.addon_context.aws_partition_id}:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:${local.addon_context.aws_partition_id}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:${local.addon_context.aws_partition_id}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:${local.addon_context.aws_partition_id}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  ]
+
+  tags = local.tags
+}
+
 output "environment" {
   value = <<EOF
+export GRAVITON_NODE_ROLE="${aws_iam_role.graviton_node.arn}"
 %{for index, id in data.aws_subnets.private.ids}
 export PRIMARY_SUBNET_${index + 1}=${id}
 %{endfor}


### PR DESCRIPTION
#### What this PR does / why we need it:

Using `eksctl` to create the node group for Graviton nodes doesn't provide much value and another potential source of issues (see #802). This PR changes that step to use the `aws` CLI directly, which is also in line with the Spot lab.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
