### PR TITLE
fix: Enable policy event logs for Pod Identity agent

### DIFF
--- a/cluster/terraform/eks.tf
+++ b/cluster/terraform/eks.tf
@@ -16,7 +16,9 @@ module "eks" {
           ENABLE_PREFIX_DELEGATION          = "true"
           POD_SECURITY_GROUP_ENFORCING_MODE = "standard"
         }
-
+        nodeAgent = {
+          enablePolicyEventLogs = "true"
+        }
         enableNetworkPolicy = "true"
       })
     }


### PR DESCRIPTION
 Changes to be committed:
	modified:   cluster/terraform/eks.tf

#### What this PR does / why we need it:
In the eks-workshop, Network section, Network Policies topic and title Debugging. The doc explains that it is possible to see the Network Policy logs via Network Policy agent. But by default the flag: enablePolicyEventLogs is set as "false".
To enable the logs, the workshop needs to pass this flag to the vpc-cni addon in the beggining of the environment setup.
I don't now about the eksctl implementation if this flags needs to be added, but at least in terraform it needs.

It will make the doc coherent for the new people that is starting to learn about EKS 
#### Which issue(s) this PR fixes:

Fixes #
Add the flag enablePolicyEventLogs as true in cluster/terraform/eks.tf
#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

I didn't run any make tests because it was taking too much time and my credentials were expiring in the middle of the test, I use identity server. At least, I ran the creation of infrastructure with terraform, it was ok so I believe the addition of the flag didn't break anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
