### PR TITLE
Fix a broken link to prefix mode

### DIFF
--- a/website/docs/networking/vpc-cni/prefix/index.md
+++ b/website/docs/networking/vpc-cni/prefix/index.md
@@ -27,4 +27,4 @@ As more Pods scheduled additional prefixes will be requested for the existing EN
 
 ![prefix-flow](prefix_flow.jpeg)
 
-Please visit [EKS best practices guide](https://aws.github.io/aws-eks-best-practices/networking/prefix-mode/) for the list of recommendations for using VPC CNI in prefix mode.
+Please visit [EKS best practices guide](https://aws.github.io/aws-eks-best-practices/networking/prefix-mode/index_linux/) for the list of recommendations for using VPC CNI in prefix mode.


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix a broken link to prefix mode

#### Which issue(s) this PR fixes:

NA

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
