### PR TITLE
Update karpenter to 0.35.4 and bump eks_blueprints_addons to 1.16.0

### DIFF
--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
@@ -9,7 +9,7 @@ data "aws_ecrpublic_authorization_token" "token" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "1.12.0"
+  version = "1.16.0"
 
   enable_karpenter = true
 
@@ -18,6 +18,7 @@ module "eks_blueprints_addons" {
   karpenter = {
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
+    chart_version = "v0.35.0"
 
     set = [{
       name  = "replicas"

--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
@@ -18,7 +18,7 @@ module "eks_blueprints_addons" {
   karpenter = {
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
-    chart_version = "v0.35.0"
+    chart_version = "0.35.4"
 
     set = [{
       name  = "replicas"

--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/main.tf
@@ -18,7 +18,7 @@ module "eks_blueprints_addons" {
   karpenter = {
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
-    chart_version = "0.35.4"
+    chart_version       = "0.35.4"
 
     set = [{
       name  = "replicas"


### PR DESCRIPTION
#### What this PR does / why we need it:
Update karpenter to latest since we were using a version not officially supported on 1.29.

#### Which issue(s) this PR fixes:

Fixes #849 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
