### PR TITLE
update: Watch all pods during cluster autoscaler scale out

### DIFF
--- a/website/docs/autoscaling/compute/cluster-autoscaler/test-ca.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/test-ca.md
@@ -24,7 +24,7 @@ $ kubectl apply -k ~/environment/eks-workshop/modules/autoscaling/compute/cluste
 Some pods will be in the `Pending` state, which triggers the cluster-autoscaler to scale out the EC2 fleet.
 
 ```bash test=false
-$ kubectl get pods -n orders -o wide --watch
+$ kubectl get pods -A -o wide --watch
 ```
 
 View the cluster-autoscaler logs


### PR DESCRIPTION
Changed the namespace filter to all

#### What this PR does / why we need it: This lab scales all the applications to 4 replicas. In that case, watching only the pods for `orders` app does not help much to see any pending pods that could be there for other applications in other namespaces. Hence this change is proposed.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
