### PR TITLE
update: Fix typo in cluster autoscaler over-provisioning seciton

### DIFF
--- a/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/how-it-works.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/how-it-works.md
@@ -40,7 +40,7 @@ How can we apply this to accomplish over-provisioning the compute in our EKS clu
 
 - A priority class with priority value **“-1"** is created and assign to empty [Pause Container](https://www.ianlewis.org/en/almighty-pause-container) Pods. The empty "pause" containers act as placeholders.
 
-- A default priority class is created priority value **“0”.** This is assigned globally for a cluster, so any deployment without a priority class will bet assigned this default priority.
+- A default priority class is created priority value **“0”.** This is assigned globally for a cluster, so any deployment without a priority class will be assigned this default priority.
 
 - When a genuine workload is scheduled the empty placeholder containers get evicted and the application Pods get provisioned immediately.
 


### PR DESCRIPTION
Corrected a typo

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
