### PR TITLE
update: Fix test explaining resources in cluster over-provisioning section

### DIFF
--- a/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/setting-up.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/setting-up.md
@@ -55,4 +55,4 @@ ip-10-42-11-81.us-west-2.compute.internal    Ready    <none>   3d      vVAR::KUB
 ip-10-42-12-152.us-west-2.compute.internal   Ready    <none>   3m11s   vVAR::KUBERNETES_NODE_VERSION
 ```
 
-These two nodes are not running any workloads except for our pause pods, which will be evicted when "real" workloads are scheduled. 
+These two nodes are not running any workloads except for our pause pods, which will be evicted when "real" workloads are scheduled.

--- a/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/setting-up.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/overprovisioning/setting-up.md
@@ -21,7 +21,7 @@ Pause pods make sure there are enough nodes that are available based on how much
 manifests/modules/autoscaling/compute/overprovisioning/setup/deployment-pause.yaml
 ```
 
-In this case we're going to schedule a single pause pod requesting `7Gi` of memory, which means it will consume almost an entire `m5.large` instance. This will result in us always having 2 "spare" worker nodes available.
+In this case we're going to schedule a single pause pod requesting `6.5Gi` of memory, which means it will consume almost an entire `m5.large` instance. This will result in us always having 2 "spare" worker nodes available.
 
 Apply the updates to your cluster:
 
@@ -55,4 +55,4 @@ ip-10-42-11-81.us-west-2.compute.internal    Ready    <none>   3d      vVAR::KUB
 ip-10-42-12-152.us-west-2.compute.internal   Ready    <none>   3m11s   vVAR::KUBERNETES_NODE_VERSION
 ```
 
-These two nodes are not running any workloads except for our pause pods, which will be evicted when "real" workloads are scheduled.
+These two nodes are not running any workloads except for our pause pods, which will be evicted when "real" workloads are scheduled. 


### PR DESCRIPTION
Corrected a typo

#### What this PR does / why we need it: The size of the memory in the description did not match the size in the yaml file.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
