### PR TITLE
Update vpc-cni to default version 1.16.0 in eksctl instructions creation

### DIFF
--- a/cluster/eksctl/cluster.yaml
+++ b/cluster/eksctl/cluster.yaml
@@ -21,7 +21,7 @@ vpc:
     publicAccess: true
 addons:
   - name: vpc-cni
-    version: 1.14.1
+    version: 1.16.0
     configurationValues: '{"env":{"ENABLE_PREFIX_DELEGATION":"true", "ENABLE_POD_ENI":"true", "POD_SECURITY_GROUP_ENFORCING_MODE":"standard"},"enableNetworkPolicy": "true"}'
     resolveConflicts: overwrite
 managedNodeGroups:


### PR DESCRIPTION
#### What this PR does / why we need it:

Just to be aligned with default version in the EKS console.
Didn't manage to find this information in https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
Terraform cluster creation use (with `most_recent` flag) so `1.18.0` as of today (see https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/patterns/aws-vpc-cni-network-policy/main.tf#L125)

Is there interesting to always use last version?
Something like:

```
aws eks describe-addon-versions --addon vpc-cni --query "addons[].addonVersions[0].addonVersion" --output text | sed "s/v\(.*\)-eksbuild.*/\\1/"
```
Might help to generate the cluster.yaml with the latest version.

#### Which issue(s) this PR fixes:

None

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
