### PR TITLE
update: Update flux module for 2.2.3

### DIFF
--- a/website/docs/automation/gitops/flux/ci.md
+++ b/website/docs/automation/gitops/flux/ci.md
@@ -72,14 +72,7 @@ The suffix `z7llv2` in the name `retail-store-sample-ui-z7llv2` is random and wi
 
 ![ci-start](assets/ecr.png)
 
-While we are waiting for pipeline to create new images (5-10 minutes), let's [automate image updates to Git](https://fluxcd.io/flux/guides/image-update/) using Flux Image Automation Controller.
-
-First, we need to install Flux components.
-
-```bash
-$ flux install --components-extra=image-reflector-controller,image-automation-controller \
-  --network-policy=false
-```
+While we are waiting for pipeline to create new images (5-10 minutes), let's [automate image updates to Git](https://fluxcd.io/flux/guides/image-update/) using Flux Image Automation Controller which we installed during the initial Flux bootstrap process.
 
 Next, edit file `deployment.yaml` and add placeholder for new container image URL:
 

--- a/website/docs/automation/gitops/flux/cluster_bootstrap.md
+++ b/website/docs/automation/gitops/flux/cluster_bootstrap.md
@@ -10,7 +10,7 @@ Before bootstrapping a cluster, Flux allows us to run pre-bootstrap checks to ve
 ```bash
 $ flux check --pre
 > checking prerequisites
-> Kubernetes VAR::KUBERNETES_NODE_VERSION >=1.20.6-0
+...
 > prerequisites checks passed
 ```
 
@@ -21,6 +21,7 @@ $ flux bootstrap git \
   --url=ssh://${GITOPS_IAM_SSH_KEY_ID}@git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos/${EKS_CLUSTER_NAME}-gitops \
   --branch=main \
   --private-key-file=${HOME}/.ssh/gitops_ssh.pem \
+  --components-extra=image-reflector-controller,image-automation-controller \
   --network-policy=false \
   --silent
 ```
@@ -29,6 +30,7 @@ Let's break down the command above:
 
 - First we tell Flux which Git repository to use to store its state
 - After that, we're passing the Git `branch` that we want this instance of Flux to use, since some patterns involve multiple branches in the same Git repository
+- We use the `--components-extra` parameter to install [additional toolkit components](https://fluxcd.io/flux/components/image/) that we'll use in the Continuous Integration section
 - Finally we'll be using SSH for Flux to connect and authenticate using the SSH key at `/home/ec2-user/gitops_ssh.pem`
 
 Now, let's verify that the bootstrap process completed successfully by running the following command:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updating the flux CLI to 2.2.3 caused an error to start appearing in the CI section:

```
this cluster has already been bootstrapped with Flux v2.2.3! Please use 'flux bootstrap' to upgrade
```

This PR slightly restructures the content so all the extra components are installed during initial `flux bootstrap` rather than using a follow-up `flux install`.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
