### PR TITLE
update: Upgraded VPC Lattice controller to 1.0.5

### DIFF
--- a/website/docs/networking/vpc-lattice/setup.md
+++ b/website/docs/networking/vpc-lattice/setup.md
@@ -40,7 +40,7 @@ $ aws ecr-public get-login-password --region us-east-1 \
   | helm registry login --username AWS --password-stdin public.ecr.aws
 $ helm install gateway-api-controller \
     oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart \
-    --version=v1.0.1 \
+    --version=v1.0.5 \
     --create-namespace \
     --set=aws.region=${AWS_REGION} \
     --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="$LATTICE_IAM_ROLE" \


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrades the VPC Lattice controller to version 1.0.5

Also improves the lab cleanup script by waiting longer for the target groups to be deleted and properly waiting for the VPC association to be deleted.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
