### PR TITLE
Update MySQL statefulset & deployments to 8.0

### DIFF
--- a/manifests/base-application/catalog/statefulset-mysql.yaml
+++ b/manifests/base-application/catalog/statefulset-mysql.yaml
@@ -24,9 +24,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: "public.ecr.aws/docker/library/mysql:5.7"
-          args:
-            - "--ignore-db-dir=lost+found"
+          image: "public.ecr.aws/docker/library/mysql:8.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/manifests/base-application/orders/deployment-mysql.yaml
+++ b/manifests/base-application/orders/deployment-mysql.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: "public.ecr.aws/docker/library/mysql:5.7"
+          image: "public.ecr.aws/docker/library/mysql:8.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/manifests/modules/fundamentals/storage/ebs/statefulset-mysql.yaml
+++ b/manifests/modules/fundamentals/storage/ebs/statefulset-mysql.yaml
@@ -25,9 +25,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: "public.ecr.aws/docker/library/mysql:5.7"
-          args:
-            - "--ignore-db-dir=lost+found"
+          image: "public.ecr.aws/docker/library/mysql:8.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/website/docs/fundamentals/storage/ebs/statefulset.md
+++ b/website/docs/fundamentals/storage/ebs/statefulset.md
@@ -23,11 +23,9 @@ Namespace:          catalog
 [...]
   Containers:
    mysql:
-    Image:      public.ecr.aws/docker/library/mysql:5.7
+    Image:      public.ecr.aws/docker/library/mysql:8.0
     Port:       3306/TCP
     Host Port:  0/TCP
-    Args:
-      --ignore-db-dir=lost+found
     Environment:
       MYSQL_ROOT_PASSWORD:  my-secret-pw
       MYSQL_USER:           <set to the key 'username' in secret 'catalog-db'>  Optional: false


### PR DESCRIPTION
#### What this PR does / why we need it:

The Security Group for Pods module provision a [RDS MySQL 8.0 instance](https://github.com/aws-samples/eks-workshop-v2/blob/main/manifests/modules/networking/securitygroups-for-pods/.workshop/terraform/preprovision/main.tf#L30) for the catalog microservice.
The statefulset still use a [5.7 version](https://github.com/aws-samples/eks-workshop-v2/blob/main/manifests/base-application/catalog/statefulset-mysql.yaml#L27) and the data model & the catalog application is compatible but it's probably better to have them in sync to avoid future problems and unnecessary participants questions about this drift.
The [`ignore-db-dir` is deprecated starting version 8](https://dev.mysql.com/doc/refman/8.0/en/added-deprecated-removed.html).
Also change the version for the orders microservice, without any other change.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

```
❯ make test module="introduction"
bash hack/run-tests.sh '' introduction '-'
Warning: Defaulting region to us-west-2
Building container images...
sha256:073782a13c08d64e3946d66076f3e7f608207e946c2353bdf22a44127c817930
sha256:6cc7a3bd10be210bf890180a089622dee76f97decf71fdaff5e4ae5fac1be9c6
Running test suite...
Updated context arn:aws:eks:us-west-2:xxx:cluster/eks-workshop in /home/ec2-user/.kube/config
Updated context arn:aws:eks:us-west-2:xxx:cluster/eks-workshop in /home/ec2-user/.kube/config


  EKS Workshop
    Unknown
      Getting started
        ✔ Getting started (12046ms)
        ✔ Deploying our first component (100671ms)
        ✔ Other components (141712ms)
      Kustomize (optional)
        ✔ Kustomize (optional) (90880ms)


  4 passing (6m)
```

EBS:
```
  EKS Workshop
    Fundamentals
      Storage
        Amazon EBS
          ✔ Amazon EBS (173908ms)
          ✔ StatefulSets (15935ms)
          ✔ EBS CSI Driver (118070ms)
          ✔ StatefulSet with EBS Volume (159091ms)


  4 passing (10m)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
