### PR TITLE
Remove extra space from command

### DIFF
--- a/website/docs/security/pod-security-standards/restricted.md
+++ b/website/docs/security/pod-security-standards/restricted.md
@@ -60,7 +60,7 @@ deployment.apps/assets configured
 Now, Run the below commands to check PSA allows the creation of Deployment and Pod with the above changes in the the `assets` namespace:
 
 ```bash
-$ kubectl -n assets  get pod
+$ kubectl -n assets get pod
 NAME                     READY   STATUS    RESTARTS   AGE
 assets-8dd6fc8c6-9kptf   1/1     Running   0          3m6s
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:
Just removing a single extra space from a command. Not critical by any means. Just helping to make it look nicer.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
