### PR TITLE
update FSxN csi driver version and install method

### DIFF
--- a/manifests/modules/fundamentals/storage/fsxn/.workshop/terraform/main.tf
+++ b/manifests/modules/fundamentals/storage/fsxn/.workshop/terraform/main.tf
@@ -1,8 +1,72 @@
-resource "aws_eks_addon" "fsxn_csi_addon" {
-  cluster_name  = var.addon_context.eks_cluster_id
-  addon_name    = "netapp_trident-operator"
-  addon_version = "v23.10.0-eksbuild.1"
+resource "aws_iam_policy" "fsxn-csi-policy" {
+  name        = "AmazonFSXNCSIDriverPolicy"
+  description = "FSxN CSI Driver Policy"
 
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "fsx:DescribeFileSystems",
+                "fsx:DescribeVolumes",
+                "fsx:CreateVolume",
+                "fsx:RestoreVolumeFromSnapshot",
+                "fsx:DescribeStorageVirtualMachines",
+                "fsx:UntagResource",
+                "fsx:UpdateVolume",
+                "fsx:TagResource",
+                "fsx:DeleteVolume"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "${aws_secretsmanager_secret.fsxn_password_secret.arn}"
+        }
+    ]
+    })
+}
+
+
+module "iam_iam-role-for-service-accounts-eks" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.37.1"
+
+  role_name              = "AmazonEKS_FSXN_CSI_DriverRole"
+  allow_self_assume_role = true
+
+  oidc_providers = {
+    eks = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["${local.k8s_service_account_namespace}:${local.k8s_service_account_name}"]
+    }
+  }
+
+  role_policy_arns = {
+    additional           = aws_iam_policy.fsxn-csi-policy.arn
+  }
+
+}
+
+locals {
+    k8s_service_account_namespace = "trident"
+    k8s_service_account_name      = "trident-controller"
+}
+
+resource "aws_secretsmanager_secret" "fsxn_password_secret" {
+  name = "fsxn_password_secret"
+  description = "FSxN CSI Driver Password"
+}
+
+resource "aws_secretsmanager_secret_version" "fsxn_password_secret" {
+    secret_id     = aws_secretsmanager_secret.fsxn_password_secret.id
+    secret_string = jsonencode({
+    username = "vsadmin"
+    password = "${random_string.fsx_password.result}"
+  })
 }
 
 data "aws_vpc" "selected_vpc_fsx" {

--- a/manifests/modules/fundamentals/storage/fsxn/.workshop/terraform/outputs.tf
+++ b/manifests/modules/fundamentals/storage/fsxn/.workshop/terraform/outputs.tf
@@ -4,5 +4,7 @@ output "environment_variables" {
     FSXN_ID             = aws_fsx_ontap_file_system.fsxnassets.id
     FSXN_ADMIN_PASSWORD = random_string.fsx_password.result
     FSXN_IP             = tolist(aws_fsx_ontap_file_system.fsxnassets.endpoints[0].management[0].ip_addresses)[0]
+    FSXN_CSI_ADDON_ROLE = module.iam_iam-role-for-service-accounts-eks.iam_role_arn
   }
 }
+

--- a/website/docs/fundamentals/storage/fsx-for-netapp-ontap/fsxn-csi-driver.md
+++ b/website/docs/fundamentals/storage/fsx-for-netapp-ontap/fsxn-csi-driver.md
@@ -9,7 +9,14 @@ The [Amazon FSx for NetApp ONTAP Container Storage Interface (CSI) Driver](https
 
 In order to utilize Amazon FSx for NetApp ONTAP file system with dynamic provisioning on our EKS cluster, we need to confirm that we have the Amazon FSx for NetApp ONTAP CSI Driver installed. The [Amazon FSx for NetApp ONTAP Container Storage Interface (CSI) Driver](https://github.com/NetApp/trident) implements the CSI specification for container orchestrators to manage the lifecycle of Amazon FSx for NetApp ONTAP file systems.
 
-As part of our workshop environment the EKS cluster has the Amazon FSx for NetApp ONTAP Container Storage Interface (CSI) Driver pre-installed. We can confirm the installation like so:
+To improve security and reduce the amount of work, you can manage the Amazon FSx for NetApp ONTAP CSI driver as an Amazon EKS add-on. The IAM role needed by the add-on was created for us so we can go ahead and install the add-on:
+```bash timeout=300 wait=60
+$ aws eks create-addon --cluster-name $EKS_CLUSTER_NAME --addon-name netapp_trident-operator \
+  --configuration-values $'"cloudIdentity": "'eks.amazonaws.com/role-arn:$FSXN_CSI_ADDON_ROLE'"'
+$ aws eks wait addon-active --cluster-name $EKS_CLUSTER_NAME --addon-name netapp_trident-operator
+```
+
+Now we can take a look at what has been created in our EKS cluster by the addon. For example, a DaemonSet will be running a pod on each node in our cluster:
 
 ```bash
 $ kubectl get pods -n trident


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove add-on install from terraform and add that to the workflow on the workshop. 
Add IAM role to the terraform 
#### Which issue(s) this PR fixes:
FSxN CSI doesn't support EKS 1.29 

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
