### PR TITLE
update: Changed Karpenter lab to install via helm chart

### DIFF
--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/cleanup.sh
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/cleanup.sh
@@ -19,3 +19,5 @@ timeout --foreground -s TERM 30 bash -c \
 if [ $EXIT_CODE -ne 0 ]; then
   logmessage "Warning: Karpenter nodes did not clean up"
 fi
+
+uninstall-helm-chart karpenter karpenter

--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/outputs.tf
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/outputs.tf
@@ -1,7 +1,9 @@
 output "environment_variables" {
   description = "Environment variables to be added to the IDE shell"
   value = {
-    KARP_ROLE = module.eks_blueprints_addons.karpenter.node_iam_role_name
-    KARP_ARN  = module.eks_blueprints_addons.karpenter.node_iam_role_arn
+    KARPENTER_VERSION   = var.karpenter_version
+    KARPENTER_SQS_QUEUE = module.karpenter.queue_name
+    KARPENTER_ROLE      = module.karpenter.node_iam_role_name
+    KARPENTER_ROLE_ARN  = module.karpenter.node_iam_role_arn
   }
 }

--- a/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/vars.tf
+++ b/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform/vars.tf
@@ -33,3 +33,10 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "karpenter_version" {
+  description = "The version of Karpenter to use"
+  type        = string
+  # renovate: datasource=github-releases depName=aws/karpenter-provider-aws
+  default = "0.35.4"
+}

--- a/manifests/modules/autoscaling/compute/karpenter/nodepool/nodepool.yaml
+++ b/manifests/modules/autoscaling/compute/karpenter/nodepool/nodepool.yaml
@@ -32,7 +32,7 @@ metadata:
   name: default
 spec:
   amiFamily: AL2 # Amazon Linux 2
-  role: "${KARP_ROLE}"
+  role: "${KARPENTER_ROLE}"
   subnetSelectorTerms:
     - tags:
         karpenter.sh/discovery: ${EKS_CLUSTER_NAME}

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,14 @@
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["manifests/modules/**/vars.tf"],
+      "matchStrings": [
+        "#\\s*renovate: datasource=(.*?) depName=(.*?)( versioning=(.*?))?(?: extractVersion=(.*?))?\\s*default\\s*=\\s*\"(.*)\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{/if}}"
     }
   ],
   "ignoreDeps": ["github.com/aws-ia/terraform-aws-eks-blueprints"]

--- a/website/docs/autoscaling/compute/karpenter/configure.md
+++ b/website/docs/autoscaling/compute/karpenter/configure.md
@@ -10,7 +10,7 @@ The first thing we'll do is install Karpenter in our cluster. Various pre-requis
 3. An EKS cluster access entry for the node IAM role so the nodes can join the EKS cluster
 4. An SQS queue for Karpenter to receive Spot interruption, instance re-balance and other events
 
-You can find the full installation documentation for Karpenter here.
+You can find the full installation documentation for Karpenter [here](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/).
 
 All that we have left to do is install Karpenter as a helm chart:
 

--- a/website/docs/autoscaling/compute/karpenter/configure.md
+++ b/website/docs/autoscaling/compute/karpenter/configure.md
@@ -1,9 +1,38 @@
 ---
-title: "Configure Karpenter"
+title: "Install Karpenter"
 sidebar_position: 20
 ---
 
-Karpenter has been installed in our EKS cluster, and runs as a deployment:
+The first thing we'll do is install Karpenter in our cluster. Various pre-requisites were created during the lab preparation stage, including:
+
+1. An IAM role for Karpenter to call AWS APIs
+2. An IAM role and instance profile for the EC2 instances that Karpenter creates
+3. An EKS cluster access entry for the node IAM role so the nodes can join the EKS cluster
+4. An SQS queue for Karpenter to receive Spot interruption, instance re-balance and other events
+
+You can find the full installation documentation for Karpenter here.
+
+All that we have left to do is install Karpenter as a helm chart:
+
+```bash
+$ helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version "${KARPENTER_VERSION}" \
+  --namespace "karpenter" --create-namespace \
+  --set "settings.clusterName=${EKS_CLUSTER_NAME}" \
+  --set "settings.interruptionQueue=${KARPENTER_SQS_QUEUE}" \
+  --set controller.resources.requests.cpu=1 \
+  --set controller.resources.requests.memory=1Gi \
+  --set controller.resources.limits.cpu=1 \
+  --set controller.resources.limits.memory=1Gi \
+  --wait
+NAME: karpenter
+LAST DEPLOYED: [...]
+NAMESPACE: karpenter
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+Karpenter will be running as a deployment in the `karpenter` namespace:
 
 ```bash
 $ kubectl get deployment -n karpenter
@@ -11,11 +40,4 @@ NAME        READY   UP-TO-DATE   AVAILABLE   AGE
 karpenter   2/2     2            2           105s
 ```
 
-The only setup that we will need to do is to update our EKS IAM mappings to allow Karpenter nodes to join the cluster:
-
-```bash
-$ eksctl create iamidentitymapping --cluster $EKS_CLUSTER_NAME \
-    --region $AWS_REGION --arn $KARP_ARN \
-    --group system:bootstrappers --group system:nodes \
-    --username system:node:{{EC2PrivateDNSName}}
-```
+Now we can move on to configuring Karpenter so that it will provision infrastructure for our pods.

--- a/website/docs/autoscaling/compute/karpenter/configure.md
+++ b/website/docs/autoscaling/compute/karpenter/configure.md
@@ -23,6 +23,7 @@ $ helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --ve
   --set controller.resources.requests.memory=1Gi \
   --set controller.resources.limits.cpu=1 \
   --set controller.resources.limits.memory=1Gi \
+  --set replicas=1 \
   --wait
 NAME: karpenter
 LAST DEPLOYED: [...]
@@ -37,7 +38,7 @@ Karpenter will be running as a deployment in the `karpenter` namespace:
 ```bash
 $ kubectl get deployment -n karpenter
 NAME        READY   UP-TO-DATE   AVAILABLE   AGE
-karpenter   2/2     2            2           105s
+karpenter   1/1     1            1           105s
 ```
 
 Now we can move on to configuring Karpenter so that it will provision infrastructure for our pods.

--- a/website/docs/autoscaling/compute/karpenter/index.md
+++ b/website/docs/autoscaling/compute/karpenter/index.md
@@ -16,7 +16,7 @@ $ prepare-environment autoscaling/compute/karpenter
 
 This will make the following changes to your lab environment:
 
-- Install Karpenter in the Amazon EKS cluster
+- Installs various IAM roles and other AWS resources required by Karpenter
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/autoscaling/compute/karpenter/.workshop/terraform).
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the Karpenter lab so its installed with a helm chart by the user instead of in the Terraform. This makes it more transparent to the user what is happening.

The Terraform is still used to create the various IAM roles, SQS queue and cluster access entries.

#### Which issue(s) this PR fixes:

Related to #863 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
