### PR TITLE
update: Changed Cluster Autoscaler lab to install via helm chart

### DIFF
--- a/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/cleanup.sh
+++ b/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+uninstall-helm-chart cluster-autoscaler kube-system

--- a/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/main.tf
+++ b/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/main.tf
@@ -7,8 +7,6 @@ module "eks_blueprints_addons" {
   cluster_version   = var.eks_cluster_version
   oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
 
-  enable_cluster_autoscaler = true
-  cluster_autoscaler = {
-    wait = true
-  }
+  enable_cluster_autoscaler   = true
+  create_kubernetes_resources = false
 }

--- a/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/outputs.tf
+++ b/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/outputs.tf
@@ -1,6 +1,8 @@
 output "environment_variables" {
   description = "Environment variables to be added to the IDE shell"
   value = {
-    CLUSTER_AUTOSCALER_ROLE = module.eks_blueprints_addons.cluster_autoscaler.iam_role_arn
+    CLUSTER_AUTOSCALER_ROLE          = module.eks_blueprints_addons.cluster_autoscaler.iam_role_arn
+    CLUSTER_AUTOSCALER_CHART_VERSION = var.cluster_autoscaler_chart_version
+    CLUSTER_AUTOSCALER_IMAGE_TAG     = "v${var.eks_cluster_version}.0"
   }
 }

--- a/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/outputs.tf
+++ b/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/outputs.tf
@@ -1,0 +1,6 @@
+output "environment_variables" {
+  description = "Environment variables to be added to the IDE shell"
+  value = {
+    CLUSTER_AUTOSCALER_ROLE = module.eks_blueprints_addons.cluster_autoscaler.iam_role_arn
+  }
+}

--- a/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/vars.tf
+++ b/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform/vars.tf
@@ -33,3 +33,10 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "cluster_autoscaler_chart_version" {
+  description = "The version of cluster-autoscaler to use"
+  type        = string
+  # renovate: datasource=helm registryUrl=https://kubernetes.github.io/autoscaler depName=cluster-autoscaler
+  default = "9.37.0"
+}

--- a/website/docs/autoscaling/compute/cluster-autoscaler/index.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/index.md
@@ -16,7 +16,7 @@ $ prepare-environment autoscaling/compute/cluster-autoscaler
 
 This will make the following changes to your lab environment:
 
-- Install the Kubernetes Cluster Autoscaler in the Amazon EKS cluster
+- Create an IAM role that will be used by cluster-autoscaler
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/autoscaling/compute/cluster-autoscaler/.workshop/terraform).
 

--- a/website/docs/autoscaling/compute/cluster-autoscaler/install.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/install.md
@@ -1,0 +1,36 @@
+---
+title: "Installation"
+sidebar_position: 30
+---
+
+The first thing we'll do is install cluster-autoscaler in our cluster. As part of the lab preparation an IAM role has already been created for cluster-autoscaler to call the appropriate AWS APIs.
+
+All that we have left to do is install cluster-autoscaler as a helm chart:
+
+```bash
+$ helm repo add autoscaler https://kubernetes.github.io/autoscaler
+$ helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler --version "9.37.0" \
+  --namespace "kube-system" \
+  --set "autoDiscovery.clusterName=${EKS_CLUSTER_NAME}" \
+  --set "awsRegion=${AWS_REGION}" \
+  --set "rbac.serviceAccount.name=cluster-autoscaler-sa" \
+  --set "image.tag=v1.29.0" \
+  --set "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"="$CLUSTER_AUTOSCALER_ROLE" \
+  --wait
+NAME: cluster-autoscaler
+LAST DEPLOYED: [...]
+NAMESPACE: kube-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+It will be running as a deployment in the `kube-system` namespace:
+
+```bash
+$ kubectl get deployment -n kube-system cluster-autoscaler-aws-cluster-autoscaler
+NAME                                        READY   UP-TO-DATE   AVAILABLE   AGE
+cluster-autoscaler-aws-cluster-autoscaler   1/1     1            1           51s
+```
+
+Now we can move on to modifying our workloads to trigger the provisioning of more compute.

--- a/website/docs/autoscaling/compute/cluster-autoscaler/install.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/install.md
@@ -9,12 +9,12 @@ All that we have left to do is install cluster-autoscaler as a helm chart:
 
 ```bash
 $ helm repo add autoscaler https://kubernetes.github.io/autoscaler
-$ helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler --version "9.37.0" \
+$ helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler --version "${CLUSTER_AUTOSCALER_CHART_VERSION}" \
   --namespace "kube-system" \
   --set "autoDiscovery.clusterName=${EKS_CLUSTER_NAME}" \
   --set "awsRegion=${AWS_REGION}" \
+  --set "image.tag=${CLUSTER_AUTOSCALER_IMAGE_TAG}" \
   --set "rbac.serviceAccount.name=cluster-autoscaler-sa" \
-  --set "image.tag=v1.29.0" \
   --set "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"="$CLUSTER_AUTOSCALER_ROLE" \
   --wait
 NAME: cluster-autoscaler

--- a/website/docs/autoscaling/compute/cluster-autoscaler/test-ca.md
+++ b/website/docs/autoscaling/compute/cluster-autoscaler/test-ca.md
@@ -3,13 +3,7 @@ title: "Scale with CA"
 sidebar_position: 40
 ---
 
-The Cluster Autoscaler component has been installed in our EKS cluster as part of the preparation for this lab. It runs as a deployment in the `kube-system` namespace:
-
-```bash
-$ kubectl get deployment -n kube-system cluster-autoscaler-aws-cluster-autoscaler
-```
-
-In this lab exercise, we'll update all of the application components to increase their replica count to 4. This will cause more resources to be consumed than are available in a cluster, triggering more compute to be provisioned.
+In this section we'll update all of the application components to increase their replica count to 4. This will cause more resources to be consumed than are available in a cluster, triggering more compute to be provisioned.
 
 ```file
 manifests/modules/autoscaling/compute/cluster-autoscaler/deployment.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the Cluster Autoscaler lab so its installed with a helm chart by the user instead of in the Terraform. This makes it more transparent to the user what is happening.

The Terraform is still used to create the IAM role, IRSA entries used by Cluster Autoscaler.

#### Which issue(s) this PR fixes:

Related to #863 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
