### PR TITLE
Update nlb.yaml

### DIFF
--- a/manifests/modules/exposing/load-balancer/nlb/nlb.yaml
+++ b/manifests/modules/exposing/load-balancer/nlb/nlb.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: ui-nlb
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
   namespace: ui


### PR DESCRIPTION
Trying to create a load balancer with type external fails and ui-nlb service remains in the pending state

Changing service.beta.kubernetes.io/aws-load-balancer-type: from external to nlb allows NLB to provision correctly

#### What this PR does / why we need it: Current YAMl fails fails to create the NLB

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
