### PR TITLE
Update vpc.md by adding Secondary CIDR pre-requirement

### DIFF
--- a/website/docs/networking/vpc-cni/custom-networking/vpc.md
+++ b/website/docs/networking/vpc-cni/custom-networking/vpc.md
@@ -55,7 +55,7 @@ $ aws ec2 describe-vpcs --vpc-ids $VPC_ID
 Here we see there are two CIDR ranges associated with the VPC:
 
 1. The `10.42.0.0/16` range which is the "primary" CIDR
-2. The `100.64.0.0/16` range which is the "secondary" CIDR
+2. The `100.64.0.0/16` range which is the "secondary" CIDR _(Please note, that this lab assumes that you have already secondary CIDR added in your Cluster's VPC, follow to associate at [VPC Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/modify-vpcs.html#add-ipv4-cidr)_
 
 You can also view this in the AWS console:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Lot of customers are facing issues following this doc by asking "Do we need to add Secondary CIDR beforehand itself?" as it's not confirmed on the Doc, however on AWS Doc it's written - https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html#custom-networking-configure-vpc (At Step 3(B))

#### Which issue(s) this PR fixes:

Fixes #
Added a Note to have Secondary CIDR as a pre-assumption while following this workshop Lab.

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
