### PR TITLE
update: Changed ArgoCD lab to install via helm chart

### DIFF
--- a/manifests/modules/automation/gitops/argocd/.workshop/cleanup.sh
+++ b/manifests/modules/automation/gitops/argocd/.workshop/cleanup.sh
@@ -7,3 +7,5 @@ logmessage "Deleting ArgoCD applications..."
 delete-all-and-wait-if-crd-exists applications.argoproj.io
 
 rm -rf ~/environment/argocd
+
+uninstall-helm-chart argocd argocd

--- a/manifests/modules/automation/gitops/argocd/.workshop/terraform/main.tf
+++ b/manifests/modules/automation/gitops/argocd/.workshop/terraform/main.tf
@@ -1,40 +1,5 @@
 data "aws_region" "current" {}
 
-module "argocd" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.25.0//modules/kubernetes-addons/argocd"
-  addon_context = var.addon_context
-
-  helm_config = {
-    name             = "argocd"
-    chart            = "argo-cd"
-    repository       = "https://argoproj.github.io/argo-helm"
-    version          = "5.36.0"
-    namespace        = "argocd"
-    timeout          = 1200
-    create_namespace = true
-
-    set = [{
-      name  = "server.replicas"
-      value = "1"
-      }, {
-      name  = "controller.replicas"
-      value = "1"
-      }, {
-      name  = "repoServer.replicas"
-      value = "1"
-      }, {
-      name  = "applicationSet.replicaCount"
-      value = "1"
-      }, {
-      name  = "redis-ha.enabled"
-      value = "false"
-      }, {
-      name  = "server.service.type"
-      value = "LoadBalancer"
-    }]
-  }
-}
-
 resource "aws_codecommit_repository" "argocd" {
   repository_name = "${var.addon_context.eks_cluster_id}-argocd"
   description     = "CodeCommit repository for ArgoCD"

--- a/manifests/modules/automation/gitops/argocd/.workshop/terraform/outputs.tf
+++ b/manifests/modules/automation/gitops/argocd/.workshop/terraform/outputs.tf
@@ -4,5 +4,6 @@ output "environment_variables" {
     GITOPS_IAM_SSH_KEY_ID  = aws_iam_user_ssh_key.gitops.id
     GITOPS_IAM_SSH_USER    = aws_iam_user.gitops.unique_id
     GITOPS_REPO_URL_ARGOCD = "ssh://${aws_iam_user_ssh_key.gitops.id}@git-codecommit.${data.aws_region.current.id}.amazonaws.com/v1/repos/${var.addon_context.eks_cluster_id}-argocd"
+    ARGOCD_CHART_VERSION   = var.argocd_chart_version
   }
 }

--- a/manifests/modules/automation/gitops/argocd/.workshop/terraform/vars.tf
+++ b/manifests/modules/automation/gitops/argocd/.workshop/terraform/vars.tf
@@ -33,3 +33,10 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "argocd_chart_version" {
+  description = "The chart version of argocd to use"
+  type        = string
+  # renovate: datasource=helm depName=argo-cd
+  default = "5.36.0"
+}

--- a/manifests/modules/automation/gitops/argocd/values.yaml
+++ b/manifests/modules/automation/gitops/argocd/values.yaml
@@ -1,0 +1,16 @@
+server:
+  replicas: 1
+  service:
+    type: LoadBalancer
+
+controller:
+  replicas: 1
+
+repoServer:
+  replicas: 1
+
+applicationSet:
+  replicaCount: 1
+
+redis-ha:
+  enabled: false

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,8 @@
       "matchDatasources": ["helm"],
       "registryUrls": [
         "https://kubernetes.github.io/autoscaler",
-        "https://kubernetes-sigs.github.io/cluster-proportional-autoscaler"
+        "https://kubernetes-sigs.github.io/cluster-proportional-autoscaler",
+        "https://argoproj.github.io/argo-helm"
       ]
     }
   ],

--- a/website/docs/automation/gitops/argocd/access_argocd.md
+++ b/website/docs/automation/gitops/argocd/access_argocd.md
@@ -1,42 +1,57 @@
 ---
-title: "Accessing Argo CD"
+title: "Installing Argo CD"
 sidebar_position: 10
 weight: 10
 ---
 
-For the purpose of this lab, Argo CD server UI has been exposed outside of the cluster using Kubernetes Service of `Load Balancer` type. To see how to set up Argo CD in the cluster with Amazon EKS Blueprint for Terraform please refer to this [guide](https://aws-ia.github.io/terraform-aws-eks-blueprints/).
-
-<!--
-:::info
-If you need to reset Argo CD `admin` password you can use the following commands:
+First lets install Argo CD in our cluster:
 
 ```bash
-$ kubectl -n argocd patch secret argocd-secret -p '{"data": {"admin.password": null, "admin.passwordMtime": null}}'
-$ kubectl -n argocd rollout restart deployment/argocd-server
-$ kubectl -n argocd rollout status deploy/argocd-server
+$ helm repo add argo-cd https://argoproj.github.io/argo-helm
+$ helm upgrade --install argocd argo-cd/argo-cd --version "${ARGOCD_CHART_VERSION}" \
+  --namespace "argocd" --create-namespace \
+  --values ~/environment/eks-workshop/modules/automation/gitops/argocd/values.yaml \
+  --wait
+NAME: argocd
+LAST DEPLOYED: [...]
+NAMESPACE: argocd
+STATUS: deployed
+REVISION: 2
+TEST SUITE: None
+NOTES:
+[...]
 ```
 
-:::
- -->
-
-To get the URL from Argo CD service, run the following command:
+For the purpose of this lab the Argo CD server UI has been exposed outside of the cluster using Kubernetes Service of `Load Balancer` type. To get the URL from Argo CD service run the following command:
 
 ```bash
-$ ARGOCD_SERVER=$(kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname')
+$ export ARGOCD_SERVER=$(kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname')
 $ echo "ArgoCD URL: http://$ARGOCD_SERVER"
 ArgoCD URL: http://acfac042a61e5467aace45fc66aee1bf-818695545.us-west-2.elb.amazonaws.com
 ```
 
-The initial username is `admin`. The password is auto-generated. You can get it by running the following command:
+The load balancer will take some time to provision so use this command to wait until ArgoCD responds:
 
 ```bash
-$ ARGOCD_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+$ curl --head -X GET --retry 20 --retry-connrefused --retry-delay 15 http://$ARGOCD_SERVER
+curl: (6) Could not resolve host: acfac042a61e5467aace45fc66aee1bf-818695545.us-west-2.elb.amazonaws.com
+Warning: Problem : timeout. Will retry in 15 seconds. 20 retries left.
+[...]
+HTTP/1.1 307 Temporary Redirect
+Content-Type: text/html; charset=utf-8
+Location: https://acfac042a61e5467aace45fc66aee1bf-818695545.us-west-2.elb.amazonaws.com/
+Date: Thu, 06 Jun 2024 23:07:42 GMT
+Content-Length: 116
+```
+
+The initial username is `admin` and the password is auto-generated. You can get it by running the following command:
+
+```bash
+$ export ARGOCD_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
 $ echo "ArgoCD admin password: $ARGOCD_PWD"
 ```
 
-Log in to the Argo CD UI using the URL and credentials you just obtained
-
-You will be presented with a screen that looks like this:
+Log in to the Argo CD UI using the URL and credentials you just obtained. You will be presented with a screen that looks like this:
 
 ![argocd-ui](assets/argocd-ui.png)
 
@@ -49,7 +64,7 @@ For the purpose of this lab, `argocd` CLI has been installed for you. You can le
 In order to interact with Argo CD objects using CLI, we need to login to the Argo CD server by running the following commands:
 
 ```bash
-$ argocd login $(kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname') --username admin --password $(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d) --insecure
+$ argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PWD --insecure
 'admin:login' logged in successfully
 Context 'acfac042a61e5467aace45fc66aee1bf-818695545.us-west-2.elb.amazonaws.com' updated
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the ArgoCD lab so its installed with a helm chart rather than the manifests that are currently used. This makes it consistent with other labs where we use helm charts and allows us to track any updates to ArgoCD with automation.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
