### PR TITLE
update: Changed Load Balancer and Ingress labs to install LBC via helm chart

### DIFF
--- a/manifests/modules/exposing/ingress/.workshop/cleanup.sh
+++ b/manifests/modules/exposing/ingress/.workshop/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+kubectl delete ingress -n catalog catalog --ignore-not-found
+kubectl delete ingress -n ui ui --ignore-not-found
+
+uninstall-helm-chart aws-load-balancer-controller kube-system

--- a/manifests/modules/exposing/ingress/.workshop/terraform/main.tf
+++ b/manifests/modules/exposing/ingress/.workshop/terraform/main.tf
@@ -2,13 +2,11 @@ module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
   version = "1.16.3"
 
-  enable_aws_load_balancer_controller = true
-  aws_load_balancer_controller = {
-    wait = true
-  }
-
   cluster_name      = var.addon_context.eks_cluster_id
   cluster_endpoint  = var.addon_context.aws_eks_cluster_endpoint
   cluster_version   = var.eks_cluster_version
   oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
+
+  enable_aws_load_balancer_controller = true
+  create_kubernetes_resources         = false
 }

--- a/manifests/modules/exposing/ingress/.workshop/terraform/outputs.tf
+++ b/manifests/modules/exposing/ingress/.workshop/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "environment_variables" {
+  description = "Environment variables to be added to the IDE shell"
+  value = {
+    LBC_CHART_VERSION = var.load_balancer_controller_chart_version
+    LBC_ROLE_ARN      = module.eks_blueprints_addons.aws_load_balancer_controller.iam_role_arn
+  }
+}

--- a/manifests/modules/exposing/ingress/.workshop/terraform/vars.tf
+++ b/manifests/modules/exposing/ingress/.workshop/terraform/vars.tf
@@ -33,3 +33,11 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "load_balancer_controller_chart_version" {
+  description = "The chart version of aws-load-balancer-controller to use"
+  type        = string
+  # renovate-helm: depName=aws-load-balancer-controller
+  default = "1.7.1"
+}
+

--- a/manifests/modules/exposing/load-balancer/.workshop/cleanup.sh
+++ b/manifests/modules/exposing/load-balancer/.workshop/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+kubectl delete svc -n ui ui-nlb --ignore-not-found
+
+uninstall-helm-chart aws-load-balancer-controller kube-system

--- a/manifests/modules/exposing/load-balancer/.workshop/terraform/main.tf
+++ b/manifests/modules/exposing/load-balancer/.workshop/terraform/main.tf
@@ -2,13 +2,11 @@ module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
   version = "1.16.3"
 
-  enable_aws_load_balancer_controller = true
-  aws_load_balancer_controller = {
-    wait = true
-  }
-
   cluster_name      = var.addon_context.eks_cluster_id
   cluster_endpoint  = var.addon_context.aws_eks_cluster_endpoint
   cluster_version   = var.eks_cluster_version
   oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
+
+  enable_aws_load_balancer_controller = true
+  create_kubernetes_resources         = false
 }

--- a/manifests/modules/exposing/load-balancer/.workshop/terraform/outputs.tf
+++ b/manifests/modules/exposing/load-balancer/.workshop/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "environment_variables" {
+  description = "Environment variables to be added to the IDE shell"
+  value = {
+    LBC_CHART_VERSION = var.load_balancer_controller_chart_version
+    LBC_ROLE_ARN      = module.eks_blueprints_addons.aws_load_balancer_controller.iam_role_arn
+  }
+}

--- a/manifests/modules/exposing/load-balancer/.workshop/terraform/vars.tf
+++ b/manifests/modules/exposing/load-balancer/.workshop/terraform/vars.tf
@@ -33,3 +33,11 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "load_balancer_controller_chart_version" {
+  description = "The chart version of aws-load-balancer-controller to use"
+  type        = string
+  # renovate-helm: depName=aws-load-balancer-controller
+  default = "1.7.1"
+}
+

--- a/website/docs/fundamentals/exposing/ingress/index.md
+++ b/website/docs/fundamentals/exposing/ingress/index.md
@@ -17,7 +17,7 @@ $ prepare-environment exposing/ingress
 
 This will make the following changes to your lab environment:
 
-- Install the AWS Load Balancer Controller in the Amazon EKS cluster
+- Creates an IAM role required by the AWS Load Balancer Controller
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/exposing/ingress/.workshop/terraform).
 

--- a/website/docs/fundamentals/exposing/ingress/introduction.md
+++ b/website/docs/fundamentals/exposing/ingress/introduction.md
@@ -3,6 +3,28 @@ title: "Introduction"
 sidebar_position: 10
 ---
 
+First lets install the AWS Load Balancer controller using helm:
+
+```bash wait=10
+$ helm repo add eks-charts https://aws.github.io/eks-charts
+$ helm upgrade --install aws-load-balancer-controller eks-charts/aws-load-balancer-controller \
+  --version "${LBC_CHART_VERSION}" \
+  --namespace "kube-system" \
+  --set "clusterName=${EKS_CLUSTER_NAME}" \
+  --set "serviceAccount.name=aws-load-balancer-controller-sa" \
+  --set "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"="$LBC_ROLE_ARN" \
+  --wait
+Release "aws-load-balancer-controller" does not exist. Installing it now.
+NAME: aws-load-balancer-controller
+LAST DEPLOYED: [...]
+NAMESPACE: kube-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+AWS Load Balancer controller installed!
+```
+
 Currently there are no Ingress resources in our cluster, which you can check with the following command:
 
 ```bash expectError=true

--- a/website/docs/fundamentals/exposing/loadbalancer/index.md
+++ b/website/docs/fundamentals/exposing/loadbalancer/index.md
@@ -17,7 +17,7 @@ $ prepare-environment exposing/load-balancer
 
 This will make the following changes to your lab environment:
 
-- Install the AWS Load Balancer Controller in the Amazon EKS cluster
+- Creates an IAM role required by the AWS Load Balancer Controller
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/exposing/load-balancer/.workshop/terraform).
 

--- a/website/docs/fundamentals/exposing/loadbalancer/introduction.md
+++ b/website/docs/fundamentals/exposing/loadbalancer/introduction.md
@@ -3,7 +3,29 @@ title: "Introduction"
 sidebar_position: 10
 ---
 
-We can confirm our microservices are only accessible internally by taking a look at the current Service resources in the cluster:
+First lets install the AWS Load Balancer controller using helm:
+
+```bash wait=10
+$ helm repo add eks-charts https://aws.github.io/eks-charts
+$ helm upgrade --install aws-load-balancer-controller eks-charts/aws-load-balancer-controller \
+  --version "${LBC_CHART_VERSION}" \
+  --namespace "kube-system" \
+  --set "clusterName=${EKS_CLUSTER_NAME}" \
+  --set "serviceAccount.name=aws-load-balancer-controller-sa" \
+  --set "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"="$LBC_ROLE_ARN" \
+  --wait
+Release "aws-load-balancer-controller" does not exist. Installing it now.
+NAME: aws-load-balancer-controller
+LAST DEPLOYED: [...]
+NAMESPACE: kube-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+AWS Load Balancer controller installed!
+```
+
+We can confirm our microservices are only accessible internally by taking a look at the current `Service` resources in the cluster:
 
 ```bash
 $ kubectl get svc -l app.kubernetes.io/created-by=eks-workshop -A
@@ -21,9 +43,9 @@ rabbitmq    rabbitmq         ClusterIP   172.20.107.54    <none>        5672/TCP
 ui          ui               ClusterIP   172.20.62.119    <none>        80/TCP                                  1h
 ```
 
-All of our application components are currently using `ClusterIP` services, which only allows access to other workloads in the same Kubernetes cluster. In order for users to access our application we need to expose the `ui` application, and in this example we'll do so using a Kubernetes Service of type `LoadBalancer`.
+All of our application components are currently using `ClusterIP` services, which only allows access to other workloads in the same Kubernetes cluster. In order for users to access our application we need to expose the `ui` application, and in this example we'll do so using a Kubernetes service of type `LoadBalancer`.
 
-First, lets take a closer look at the current specification of the Service for the `ui` component:
+Lets take a closer look at the current specification of the service for the `ui` component:
 
 ```bash
 $ kubectl -n ui describe service ui


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the Load Balancer and Ingress labs so the aws-load-balancer-controller is installed by the user with a helm chart rather than by the Terraform. This makes it consistent with other labs where we use helm charts and allows us to track any updates to the aws-load-balancer-controller with automation.

#### Which issue(s) this PR fixes:

Related to #863 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
