### PR TITLE
new: Added lab on Helm

### DIFF
--- a/manifests/modules/introduction/helm/.workshop/cleanup.sh
+++ b/manifests/modules/introduction/helm/.workshop/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+uninstall-helm-chart nginx nginx

--- a/manifests/modules/introduction/helm/.workshop/terraform/outputs.tf
+++ b/manifests/modules/introduction/helm/.workshop/terraform/outputs.tf
@@ -1,0 +1,6 @@
+output "environment_variables" {
+  description = "Environment variables to be added to the IDE shell"
+  value = {
+    NGINX_CHART_VERSION = var.nginx_chart_version
+  }
+}

--- a/manifests/modules/introduction/helm/.workshop/terraform/vars.tf
+++ b/manifests/modules/introduction/helm/.workshop/terraform/vars.tf
@@ -1,0 +1,42 @@
+# tflint-ignore: terraform_unused_declarations
+variable "eks_cluster_id" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "eks_cluster_version" {
+  description = "EKS cluster version"
+  type        = string
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "cluster_security_group_id" {
+  description = "EKS cluster security group ID"
+  type        = any
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "addon_context" {
+  description = "Addon context that can be passed directly to blueprints addon modules"
+  type        = any
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "tags" {
+  description = "Tags to apply to AWS resources"
+  type        = any
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "resources_precreated" {
+  description = "Have expensive resources been created already"
+  type        = bool
+}
+
+variable "nginx_chart_version" {
+  description = "The chart version of nginx to use"
+  type        = string
+  # renovate-helm: depName=nginx registryUrl=https://charts.bitnami.com/bitnami
+  default = "18.0.3"
+}

--- a/manifests/modules/introduction/helm/values.yaml
+++ b/manifests/modules/introduction/helm/values.yaml
@@ -1,0 +1,8 @@
+podLabels:
+  team: team1
+  costCenter: org1
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -56,7 +56,7 @@ bitnami/postgresql      X.X.X           X.X.X           PostgreSQL (Postgres) is
 
 ## Installing a Helm chart
 
-Lets install an NGINX server in our EKS cluster using the Helm chart we found above. When you install a chart using the Helm package manager, it creates a new **release** for that chart. Each release is tracked by Helm and can be upgraded, rolled back, or uninstalled independently from other releases.
+Let's install an NGINX server in our EKS cluster using the Helm chart we found above. When you install a chart using the Helm package manager, it creates a new **release** for that chart. Each release is tracked by Helm and can be upgraded, rolled back, or uninstalled independently from other releases.
 
 ```bash
 $ echo $NGINX_CHART_VERSION

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -91,7 +91,7 @@ nginx-55fbd7f494-zplwx   1/1     Running   0          119s
 
 ## Configuring chart options
 
-In the example above we installed the NGINX chart in its default configuration. However its common to need to provide **values** to charts during installation to change different aspects of behavior of the installed component.
+In the example above we installed the NGINX chart in its default configuration. Sometimes you'll need to provide configuration **values** to charts during installation to modify the way the component behaves.
 
 You can provide values to charts during installation using various methods, with two common ways being:
 

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -93,7 +93,7 @@ nginx-55fbd7f494-zplwx   1/1     Running   0          119s
 
 In the example above we installed the NGINX chart in its default configuration. Sometimes you'll need to provide configuration **values** to charts during installation to modify the way the component behaves.
 
-You can provide values to charts during installation using various methods, with two common ways being:
+There are two common ways to provide values to charts during installation:
 
 1. Create YAML files and pass them to Helm using the `-f` or `--values` flag
 1. Pass values using the `--set` flag followed by `key=value` pairs

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -124,7 +124,7 @@ NAME 	 NAMESPACE  REVISION  UPDATED                                  STATUS    C
 nginx	 nginx      2         2024-06-11 04:13:53.862100855 +0000 UTC  deployed  nginx-X.X.X   X.X.X
 ```
 
-You'll notice that the **revision** column has updated to **2** as Helm has applied our updated configuration as a distinct revision. This would allow us to rollback to our previous configurion if necessary.
+You'll notice that the **revision** column has updated to **2** as Helm has applied our updated configuration as a distinct revision. This would allow us to rollback to our previous configuration if necessary.
 
 You can view the revision history of a given release like this:
 

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -156,3 +156,5 @@ $ helm uninstall nginx --namespace nginx --wait
 ```
 
 This will delete all the resources created by the chart for that release from our EKS cluster.
+
+Now that you understand how Helm works, proceed to the [Fundamentals module](/docs/fundamentals).

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -98,7 +98,7 @@ You can provide values to charts during installation using various methods, with
 1. Create YAML files and pass them to Helm using the `-f` or `--values` flag
 1. Pass values using the `--set` flag followed by `key=value` pairs
 
-Lets combine these methods to update our NGINX release. We'll use this `values.yaml` file:
+Let's combine these methods to update our NGINX release. We'll use this `values.yaml` file:
 
 ```file
 manifests/modules/introduction/helm/values.yaml

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -38,7 +38,7 @@ $ helm version
 
 A Helm repository is a centralized location where Helm charts are stored and managed, and allow users to easily discover, share, and install charts. They facilitate easy access to a wide range of pre-packaged applications and services for deployment on Kubernetes clusters.
 
-Lets add the `bitnami` repository to our Helm CLI:
+The [Bitnami](https://github.com/bitnami/charts) Helm repository is a collection of Helm charts for deploying popular applications and tools on Kubernetes. Let's add the `bitnami` repository to our Helm CLI:
 
 ```bash
 $ helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -1,5 +1,5 @@
 ---
-title: Helm
+title: Helm (optional)
 sidebar_position: 50
 ---
 

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -116,7 +116,7 @@ $ helm upgrade --install nginx bitnami/nginx \
   --values ~/environment/eks-workshop/modules/introduction/helm/values.yaml
 ```
 
-As before lets list the releases:
+List the releases:
 
 ```bash
 $ helm list -A

--- a/website/docs/introduction/helm/index.md
+++ b/website/docs/introduction/helm/index.md
@@ -1,0 +1,158 @@
+---
+title: Helm
+sidebar_position: 50
+---
+
+{{% required-time %}}
+
+:::tip Before you start
+Prepare your environment for this section:
+
+```bash timeout=600 wait=10
+$ prepare-environment introduction/helm
+```
+
+:::
+
+Although we will primarily be interacting with kustomize in this workshop, there will be situations where Helm will be used to install certain packages in the EKS cluster. In this lab we give a brief introduction to Helm, and we'll demonstrate how to use it to install a pre-packaged application.
+
+:::info
+
+This lab doesn't not cover the authoring of Helm charts for your own workloads. For more information on this topic see this [guide](https://helm.sh/docs/chart_template_guide/).
+
+:::
+
+[Helm](https://helm.sh) is a package manager for Kubernetes that helps you define, install, and upgrade Kubernetes applications. It uses a packaging format called charts, which contain all the necessary Kubernetes resource definitions to run an application. Helm simplifies the deployment and management of applications on Kubernetes clusters.
+
+## Helm CLI
+
+The `helm` CLI tool is typically used in conjunction with a Kubernetes cluster to manage the deployment and lifecycle of applications. It provides a consistent and repeatable way to package, install, and manage applications on Kubernetes, making it easier to automate and standardize application deployments across different environments.
+
+The CLI is already installed in our IDE:
+
+```bash
+$ helm version
+```
+
+## Helm repositories
+
+A Helm repository is a centralized location where Helm charts are stored and managed, and allow users to easily discover, share, and install charts. They facilitate easy access to a wide range of pre-packaged applications and services for deployment on Kubernetes clusters.
+
+Lets add the `bitnami` repository to our Helm CLI:
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm repo update
+```
+
+Now we can search the repository for charts, for example the `postgresql` chart:
+
+```bash
+$ helm search repo postgresql
+NAME                    CHART VERSION   APP VERSION     DESCRIPTION
+bitnami/postgresql      X.X.X           X.X.X           PostgreSQL (Postgres) is an open source object-...
+[...]
+```
+
+## Installing a Helm chart
+
+Lets install an NGINX server in our EKS cluster using the Helm chart we found above. When you install a chart using the Helm package manager, it creates a new **release** for that chart. Each release is tracked by Helm and can be upgraded, rolled back, or uninstalled independently from other releases.
+
+```bash
+$ echo $NGINX_CHART_VERSION
+$ helm install nginx bitnami/nginx \
+  --version $NGINX_CHART_VERSION \
+  --namespace nginx --create-namespace --wait
+```
+
+We can break this command down as follows:
+
+- Use the `install` sub-command to instruct Helm to install a chart
+- Name the release `nginx`
+- Use the chart `bitnami/nginx` with the version $NGINX_CHART_VERSION
+- Install the chart in the `nginx` namespace and create that namespace first
+- Wait for pods in the release to get to a ready state
+
+Once the chart has installed we can list the releases in our EKS cluster:
+
+```bash
+$ helm list -A
+NAME 	 NAMESPACE  REVISION  UPDATED                                  STATUS    CHART         APP VERSION
+nginx	 nginx      1         2024-06-11 03:58:39.862100855 +0000 UTC  deployed  nginx-X.X.X   X.X.X
+```
+
+We can also see NGINX running in the namespace we specified:
+
+```bash
+$ kubectl get pod -n nginx
+NAME                     READY   STATUS    RESTARTS   AGE
+nginx-55fbd7f494-zplwx   1/1     Running   0          119s
+```
+
+## Configuring chart options
+
+In the example above we installed the NGINX chart in its default configuration. However its common to need to provide **values** to charts during installation to change different aspects of behavior of the installed component.
+
+You can provide values to charts during installation using various methods, with two common ways being:
+
+1. Create YAML files and pass them to Helm using the `-f` or `--values` flag
+1. Pass values using the `--set` flag followed by `key=value` pairs
+
+Lets combine these methods to update our NGINX release. We'll use this `values.yaml` file:
+
+```file
+manifests/modules/introduction/helm/values.yaml
+```
+
+This adds several custom Kubernetes labels to the NGINX pods, as well as setting some resource requests.
+
+We'll also add additional replicas using the `--set` flag:
+
+```bash
+$ helm upgrade --install nginx bitnami/nginx \
+  --version $NGINX_CHART_VERSION \
+  --namespace nginx --create-namespace --wait \
+  --set replicaCount=3 \
+  --values ~/environment/eks-workshop/modules/introduction/helm/values.yaml
+```
+
+As before lets list the releases:
+
+```bash
+$ helm list -A
+NAME 	 NAMESPACE  REVISION  UPDATED                                  STATUS    CHART         APP VERSION
+nginx	 nginx      2         2024-06-11 04:13:53.862100855 +0000 UTC  deployed  nginx-X.X.X   X.X.X
+```
+
+You'll notice that the **revision** column has updated to **2** as Helm has applied our updated configuration as a distinct revision. This would allow us to rollback to our previous configurion if necessary.
+
+You can view the revision history of a given release like this:
+
+```bash
+$ helm history nginx -n nginx
+REVISION  UPDATED                   STATUS      CHART        APP VERSION  DESCRIPTION
+1         Tue Jun 11 03:58:39 2024  superseded  nginx-X.X.X  X.X.X       Install complete
+2         Tue Jun 11 04:13:53 2024  deployed    nginx-X.X.X  X.X.X       Upgrade complete
+```
+
+To check that our changes have taken effect list the pods in the `nginx` namespace:
+
+```bash
+$ kubectl get pods -n nginx
+NAME                     READY   STATUS    RESTARTS   AGE
+nginx-55fbd7f494-4hz9b   1/1     Running   0          30s
+nginx-55fbd7f494-gkr2j   1/1     Running   0          30s
+nginx-55fbd7f494-zplwx   1/1     Running   0          5m
+```
+
+You can see we now have 3 replicas of the NGINX pod running.
+
+## Removing releases
+
+We can similarly uninstall a release using the CLI:
+
+```bash
+$ helm uninstall nginx --namespace nginx --wait
+```
+
+This will delete all the resources created by the chart for that release from our EKS cluster.

--- a/website/docs/introduction/helm/tests/hook-suite.sh
+++ b/website/docs/introduction/helm/tests/hook-suite.sh
@@ -1,0 +1,11 @@
+set -e
+
+before() {
+  echo "noop"
+}
+
+after() {
+  prepare-environment
+}
+
+"$@"

--- a/website/docs/introduction/kustomize/index.md
+++ b/website/docs/introduction/kustomize/index.md
@@ -82,6 +82,6 @@ $ kubectl kustomize ~/environment/eks-workshop/base-application \
 
 This uses `envsubst` to substitute environment variable placeholders in the Kubernetes manifest files with the actual values based on your particular environment. For example in some manifests we need to reference the EKS cluster name with `$EKS_CLUSTER_NAME` or the AWS region with `$AWS_REGION`.
 
-Now that you understand how Kustomize works, proceed to the [Fundamentals module](/docs/fundamentals).
+Now that you understand how Kustomize works, you can proceed to the [Helm module](/docs/introduction/helm) or go directly to the [Fundamentals module](/docs/fundamentals).
 
 To learn more about Kustomize, you can refer to the official Kubernetes [documentation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/).


### PR DESCRIPTION
#### What this PR does / why we need it:

With multiple labs now directing the user to install helm charts manually we should cover Helm basics so its clear whats happening. This provides an equivalent to the Kustomize introduction lab but for 3rd party components instead of the sample application.

#### Which issue(s) this PR fixes:

Related to #863 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
