### PR TITLE
fix: Improved contrast for links and yaml highlights in dark mode

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -45,6 +45,11 @@
   --ifm-navbar-background-color: #000716;
   --ifm-background-color: #0f1b2a;
   --ifm-menu-color: #d1d5db;
+  --ifm-menu-color-active: #ff9900;
+  --ifm-breadcrumb-color-active: #ff9900;
+  --ifm-link-color: #ff9900;
+  --ifm-tabs-color-active: #ff9900;
+  --ifm-tabs-color-active-border: #ff9900;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
@@ -77,6 +82,14 @@
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
+}
+
+[data-theme="dark"] .code-block-highlighted-line-even {
+  background-color: #d1d1d121;
+}
+
+[data-theme="dark"] .code-block-highlighted-line-odd {
+  background-color: #8c949480;
 }
 
 .theme-doc-toc-desktop {
@@ -203,11 +216,6 @@
 
 .close {
   color: white;
-}
-
-/* Dark mode specific styles */
-[data-theme="dark"] img {
-  box-shadow: 0 4px 8px rgba(255, 255, 255, 0.1);
 }
 
 [class^="lightToggleIcon"] {


### PR DESCRIPTION
#### What this PR does / why we need it:

In dark mode the website lacked contrast for links and the highlight tones for the YAML annotations did not fit the Prism theme. This PR adjusts both of these.

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
