### PR TITLE
update: Migrate OSS metrics lab to OpenTelemetry operator

### DIFF
--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/main.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/main.tf
@@ -1,16 +1,21 @@
 data "aws_partition" "current" {}
 
-module "aws_ebs_csi_driver" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.25.0//modules/kubernetes-addons/aws-ebs-csi-driver"
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.39.1"
 
-  enable_amazon_eks_aws_ebs_csi_driver = true
+  role_name_prefix = "${var.addon_context.eks_cluster_id}-ebs-csi-"
 
-  addon_config = {
-    kubernetes_version = var.eks_cluster_version
-    preserve           = false
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = var.addon_context.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
   }
 
-  addon_context = var.addon_context
+  tags = var.tags
 }
 
 module "eks_blueprints_addons" {
@@ -22,6 +27,15 @@ module "eks_blueprints_addons" {
   cluster_version   = var.eks_cluster_version
   oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
 
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      most_recent              = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+      preserve                 = false
+      configuration_values     = jsonencode({ defaultStorageClass = { enabled = true } })
+    }
+  }
+
   enable_aws_load_balancer_controller = true
   aws_load_balancer_controller = {
     wait = true
@@ -30,29 +44,54 @@ module "eks_blueprints_addons" {
 
 resource "time_sleep" "blueprints_addons_sleep" {
   depends_on = [
-    module.eks_blueprints_addons,
-    module.aws_ebs_csi_driver
+    module.eks_blueprints_addons
   ]
 
   create_duration = "15s"
 }
 
-module "adot_operator" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.25.0//modules/kubernetes-addons/opentelemetry-operator"
+module "cert_manager" {
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.1"
 
   depends_on = [
     time_sleep.blueprints_addons_sleep
   ]
 
-  addon_config = {
-    kubernetes_version = var.eks_cluster_version
-    addon_version      = "v0.92.1-eksbuild.1"
-    most_recent        = false
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+  chart            = "cert-manager"
+  chart_version    = "v1.15.1"
+  repository       = "https://charts.jetstack.io"
 
-    preserve = false
-  }
+  set = [
+    {
+      name  = "crds.enabled"
+      value = true
+    }
+  ]
+}
 
-  addon_context = var.addon_context
+module "opentelemetry_operator" {
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.1"
+
+  depends_on = [
+    module.cert_manager
+  ]
+
+  name             = "opentelemetry"
+  namespace        = "opentelemetry-operator-system"
+  create_namespace = true
+  chart            = "opentelemetry-operator"
+  chart_version    = var.operator_chart_version
+  repository       = "https://open-telemetry.github.io/opentelemetry-helm-charts"
+
+  set = [{
+    name  = "manager.collectorImage.repository"
+    value = "otel/opentelemetry-collector-k8s"
+  }]
 }
 
 resource "aws_prometheus_workspace" "this" {
@@ -62,8 +101,9 @@ resource "aws_prometheus_workspace" "this" {
 }
 
 module "iam_assumable_role_adot" {
-  source       = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version      = "5.39.1"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.39.1"
+
   create_role  = true
   role_name    = "${var.addon_context.eks_cluster_id}-adot-collector"
   provider_url = var.addon_context.eks_oidc_issuer_url

--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/vars.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/vars.tf
@@ -33,3 +33,10 @@ variable "resources_precreated" {
   description = "Have expensive resources been created already"
   type        = bool
 }
+
+variable "operator_chart_version" {
+  description = "The chart version of opentelemetry-operator to use"
+  type        = string
+  # renovate-helm: depName=opentelemetry-operator registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
+  default = "0.64.3"
+}

--- a/manifests/modules/observability/oss-metrics/adot/opentelemetrycollector.yaml
+++ b/manifests/modules/observability/oss-metrics/adot/opentelemetrycollector.yaml
@@ -1,13 +1,13 @@
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: adot
   namespace: other
 spec:
-  image: public.ecr.aws/aws-observability/aws-otel-collector:v0.21.0
+  image: public.ecr.aws/aws-observability/aws-otel-collector:v0.40.0
   mode: deployment
   serviceAccount: adot-collector
-  config: |
+  config:
     receivers:
       prometheus:
         config:
@@ -19,7 +19,7 @@ spec:
               account_id: ${AWS_ACCOUNT_ID}
               region: ${AWS_REGION}
           scrape_configs:
-            - job_name: 'kubernetes-kubelet'
+            - job_name: "kubernetes-kubelet"
               scrape_interval: 60s
               scrape_timeout: 15s
               scheme: https
@@ -28,57 +28,61 @@ spec:
                 insecure_skip_verify: true
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               kubernetes_sd_configs:
-              - role: node
+                - role: node
               relabel_configs:
-              - action: labelmap
-                regex: __meta_kubernetes_node_label_(.+)
-              - target_label: __address__
-                replacement: kubernetes.default.svc.cluster.local:443
-              - source_labels: [__meta_kubernetes_node_name]
-                regex: (.+)
-                target_label: __metrics_path__
-                replacement: /api/v1/nodes/$${1}/proxy/metrics
-            - job_name: 'kubelet'
+                - action: labelmap
+                  regex: __meta_kubernetes_node_label_(.+)
+                - target_label: __address__
+                  replacement: kubernetes.default.svc.cluster.local:443
+                - source_labels: [__meta_kubernetes_node_name]
+                  regex: (.+)
+                  target_label: __metrics_path__
+                  replacement: /api/v1/nodes/$${1}/proxy/metrics
+            - job_name: "kubelet"
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 insecure_skip_verify: true
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               kubernetes_sd_configs:
-              - role: node
+                - role: node
               relabel_configs:
-              - action: labelmap
-                regex: __meta_kubernetes_node_label_(.+)
-              - target_label: __address__
-                replacement: kubernetes.default.svc.cluster.local:443
-              - source_labels: [__meta_kubernetes_node_name]
-                regex: (.+)
-                target_label: __metrics_path__
-                replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
-            - job_name: 'kubernetes-pods'
+                - action: labelmap
+                  regex: __meta_kubernetes_node_label_(.+)
+                - target_label: __address__
+                  replacement: kubernetes.default.svc.cluster.local:443
+                - source_labels: [__meta_kubernetes_node_name]
+                  regex: (.+)
+                  target_label: __metrics_path__
+                  replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
+            - job_name: "kubernetes-pods"
               honor_labels: true
 
               kubernetes_sd_configs:
                 - role: pod
 
               relabel_configs:
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
                   action: keep
                   regex: true
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
                   action: drop
                   regex: true
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
                   action: replace
                   regex: (https?)
                   target_label: __scheme__
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_prometheus_io_path]
                   action: replace
                   target_label: __metrics_path__
                   regex: (.+)
                 - action: labelmap
                   regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
-                  replacement: __param_$1
+                  replacement: __param_$$1
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
                 - source_labels: [__meta_kubernetes_namespace]
@@ -101,7 +105,7 @@ spec:
       sigv4auth:
         region: ${AWS_REGION}
         service: aps
-      health_check:
+      health_check: {}
       pprof:
         endpoint: :1888
       zpages:
@@ -111,4 +115,5 @@ spec:
       pipelines:
         metrics:
           receivers: [prometheus]
+          processors: []
           exporters: [logging, prometheusremotewrite]


### PR DESCRIPTION
#### What this PR does / why we need it:

Migrating to EKS 1.30 was a priority to remain updated, but the ADOT addon does not currently support 1.30. Until this is the case this lab uses the upstream OpenTelemetry operator with the ADOT collector images.

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
