### PR TITLE
update: Fix inconsistent deployment name in Resource View section

### DIFF
--- a/website/docs/observability/resource-view/workloads-view/deployment_view.md
+++ b/website/docs/observability/resource-view/workloads-view/deployment_view.md
@@ -7,6 +7,6 @@ A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deploym
 
 ![Insights](/img/resource-view/deploymentSet.jpg)
 
-Click on the deployment <i>orders</i> and explore the configuration. You will see deployment strategy under Info, pod details under Pods, labels and deployment revision.
+Click on the deployment <i>carts</i> and explore the configuration. You will see deployment strategy under Info, pod details under Pods, labels and deployment revision.
 
 ![Insights](/img/resource-view/deployment-detail.jpg)


### PR DESCRIPTION
Name of the deployment is wrong. It is mentioned "orders" but it should be "carts"

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
