### PR TITLE
fix: Corrected typo in ADOT manifest breakdowns

### DIFF
--- a/website/docs/observability/container-insights/collect-metrics-adot-ci.md
+++ b/website/docs/observability/container-insights/collect-metrics-adot-ci.md
@@ -14,7 +14,7 @@ You can view the full collector manifest below, then we'll break it down.
 
 </details>
 
-We can review this is several parts to make better sense of it.
+We can review this in several parts to make better sense of it.
 
 ::yaml{file="manifests/modules/observability/container-insights/adot/opentelemetrycollector.yaml" zoomPath="spec.image" zoomAfter="1"}
 

--- a/website/docs/observability/container-insights/visualize-application-metrics-cloudwatch.md
+++ b/website/docs/observability/container-insights/visualize-application-metrics-cloudwatch.md
@@ -54,7 +54,7 @@ You'll recall the collector we've already deployed was a DaemonSet, meaning that
 
 </details>
 
-We can review this is several parts to make better sense of it.
+We can review this in several parts to make better sense of it.
 
 ::yaml{file="manifests/modules/observability/container-insights/adot-deployment/opentelemetrycollector.yaml" zoomPath="spec.image" zoomAfter="1"}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Corrects a typo introducing how the ADOT manifests are broken down.

#### Which issue(s) this PR fixes:

Fixes #1046 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
