### PR TITLE
fix: Allow appropriate IDE KMS permissions for Terraform cluster creation

### DIFF
--- a/lab/iam/policies/base.yaml
+++ b/lab/iam/policies/base.yaml
@@ -70,14 +70,15 @@ Statement:
       - kms:GenerateDataKeyWithoutPlaintext
     Resource: ["*"]
     Condition:
-      StringLike:
-        kms:RequestAlias: "alias/${Env}*"
+      ForAnyValue:StringLike:
+        kms:RequestAlias: ["alias/${Env}*", "alias/eks/${Env}*"]
   - Effect: Allow
     Action:
       - kms:CreateAlias
       - kms:DeleteAlias
     Resource:
       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/${Env}*
+      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/eks/${Env}*
       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
   - Effect: Allow
     Action:

--- a/lab/iam/policies/base.yaml
+++ b/lab/iam/policies/base.yaml
@@ -70,7 +70,7 @@ Statement:
       - kms:GenerateDataKeyWithoutPlaintext
     Resource: ["*"]
     Condition:
-      ForAnyValue:StringLike:
+      StringLike:
         kms:RequestAlias: ["alias/${Env}*", "alias/eks/${Env}*"]
   - Effect: Allow
     Action:


### PR DESCRIPTION
#### What this PR does / why we need it:

KMS IAM permissions provided to the IDE need to be expanded to account for the KMS alias pattern of the EKS Terraform module. This allows an EKS cluster to be created using Terraform route correctly.

#### Which issue(s) this PR fixes:

Fixes #1091

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
