### PR TITLE
fix: Resolve instability with SG for Pods lab cleanup

### DIFF
--- a/manifests/modules/networking/securitygroups-for-pods/.workshop/cleanup.sh
+++ b/manifests/modules/networking/securitygroups-for-pods/.workshop/cleanup.sh
@@ -6,18 +6,6 @@ logmessage "Deleting Security Group policies..."
 
 kubectl delete SecurityGroupPolicy --all -A
 
-sleep 10
+sleep 30
 
-# Clear the catalog pods so the SG can be deleted
-kubectl rollout restart -n catalog deployment/catalog
-
-logmessage "Terminating EKS worker nodes..."
-
-INSTANCE_IDS=$(aws autoscaling describe-auto-scaling-groups --filters "Name=tag:eks:nodegroup-name,Values=$EKS_DEFAULT_MNG_NAME" "Name=tag:eks:cluster-name,Values=$EKS_CLUSTER_NAME" --query 'AutoScalingGroups[0].Instances[].InstanceId' --output text)
-
-for INSTANCE_ID in $INSTANCE_IDS
-do
-  aws ec2 terminate-instances --instance-ids $INSTANCE_ID
-done
-
-sleep 60
+kubectl delete namespace catalog


### PR DESCRIPTION
#### What this PR does / why we need it:

User reports and automated tests show instability in the SG for Pods lab cleanup script. This seems to be related to a wide variability in how long it takes the worker nodes to be replaced when they are terminated in cleanup.

This change removes the node termination and instead deletes the `catalog` namespace, which should clean up all modifications made during this lab.

#### Which issue(s) this PR fixes:

Related to #1062 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
