### PR TITLE
fix: Make sure NLBs are provisioned

### DIFF
--- a/manifests/modules/networking/vpc-lattice/.workshop/terraform/main.tf
+++ b/manifests/modules/networking/vpc-lattice/.workshop/terraform/main.tf
@@ -68,6 +68,8 @@ data "aws_vpc" "this" {
 }
 
 resource "kubernetes_manifest" "ui_nlb" {
+  depends_on = [module.eks_blueprints_addons]
+
   manifest = {
     "apiVersion" = "v1"
     "kind"       = "Service"
@@ -75,7 +77,7 @@ resource "kubernetes_manifest" "ui_nlb" {
       "name"      = "ui-nlb"
       "namespace" = "ui"
       "annotations" = {
-        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external "
+        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external"
         "service.beta.kubernetes.io/aws-load-balancer-scheme"          = "internet-facing"
         "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "instance"
       }

--- a/manifests/modules/security/eks-pod-identity/.workshop/terraform/main.tf
+++ b/manifests/modules/security/eks-pod-identity/.workshop/terraform/main.tf
@@ -26,6 +26,8 @@ resource "time_sleep" "wait" {
 }
 
 resource "kubernetes_manifest" "ui_nlb" {
+  depends_on = [module.eks_blueprints_addons]
+
   manifest = {
     "apiVersion" = "v1"
     "kind"       = "Service"
@@ -33,7 +35,7 @@ resource "kubernetes_manifest" "ui_nlb" {
       "name"      = "ui-nlb"
       "namespace" = "ui"
       "annotations" = {
-        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external "
+        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external"
         "service.beta.kubernetes.io/aws-load-balancer-scheme"          = "internet-facing"
         "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "instance"
       }

--- a/manifests/modules/security/irsa/.workshop/terraform/main.tf
+++ b/manifests/modules/security/irsa/.workshop/terraform/main.tf
@@ -26,6 +26,8 @@ resource "time_sleep" "wait" {
 }
 
 resource "kubernetes_manifest" "ui_nlb" {
+  depends_on = [module.eks_blueprints_addons]
+
   manifest = {
     "apiVersion" = "v1"
     "kind"       = "Service"
@@ -33,7 +35,7 @@ resource "kubernetes_manifest" "ui_nlb" {
       "name"      = "ui-nlb"
       "namespace" = "ui"
       "annotations" = {
-        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external "
+        "service.beta.kubernetes.io/aws-load-balancer-type"            = "external"
         "service.beta.kubernetes.io/aws-load-balancer-scheme"          = "internet-facing"
         "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "instance"
       }

--- a/website/docs/security/amazon-eks-pod-identity/verifying-dynamo.md
+++ b/website/docs/security/amazon-eks-pod-identity/verifying-dynamo.md
@@ -6,8 +6,9 @@ sidebar_position: 35
 Now, with the `carts` Service Account associated with the authorized IAM role, the `carts` Pod has permission to access the DynamoDB table. Access the web store again and navigate to the shopping cart.
 
 ```bash
-$ kubectl -n ui get service ui-nlb -o jsonpath='{.status.loadBalancer.ingress[*].hostname}{"\n"}'
-k8s-ui-uinlb-647e781087-6717c5049aa96bd9.elb.us-west-2.amazonaws.com
+$ LB_HOSTNAME=$(kubectl -n ui get service ui-nlb -o jsonpath='{.status.loadBalancer.ingress[*].hostname}{"\n"}')
+$ echo "http://$LB_HOSTNAME"
+http://k8s-ui-uinlb-647e781087-6717c5049aa96bd9.elb.us-west-2.amazonaws.com
 ```
 
 The `carts` Pod is able to reach the DynamoDB service and the shopping cart is now accessible!

--- a/website/docs/security/iam-roles-for-service-accounts/verifying-dynamo.md
+++ b/website/docs/security/iam-roles-for-service-accounts/verifying-dynamo.md
@@ -6,8 +6,9 @@ sidebar_position: 25
 Now, with the `carts` Service Account annotated with the authorized IAM role, the `carts` Pod has permission to access the DynamoDB table. Access the web store again and navigate to the shopping cart.
 
 ```bash
-$ kubectl get service -n ui ui-nlb -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
-k8s-ui-uinlb-647e781087-6717c5049aa96bd9.elb.us-west-2.amazonaws.com
+$ LB_HOSTNAME=$(kubectl -n ui get service ui-nlb -o jsonpath='{.status.loadBalancer.ingress[*].hostname}{"\n"}')
+$ echo "http://$LB_HOSTNAME"
+http://k8s-ui-uinlb-647e781087-6717c5049aa96bd9.elb.us-west-2.amazonaws.com
 ```
 
 The `carts` Pod is able to reach the DynamoDB service and the shopping cart is now accessible!


### PR DESCRIPTION
#### What this PR does / why we need it:

A type in the annotations for several load balancers was causing classic load balancers to be created instead of NLBs.

Also changed how the URLs for the load balancers are displayed so that browser doesn't try HTTPS automatically

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
