### PR TITLE
Fixing log command

### DIFF
--- a/website/docs/autoscaling/compute/karpenter/consolidation.md
+++ b/website/docs/autoscaling/compute/karpenter/consolidation.md
@@ -51,7 +51,7 @@ $ kubectl scale -n other deployment/inflate --replicas 5
 We can check the Karpenter logs to get an idea of what actions it took in response to our scaling in the deployment. Wait about 5-10 seconds before running the following command:
 
 ```bash test=false
-$ kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'consolidation delete' | jq '.'
+$ kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'disrupting nodeclaim(s) via delete' | jq '.'
 ```
 
 The output will show Karpenter identifying specific nodes to cordon, drain and then terminate:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixing print Karpenter log command that changed due to Karpenter v1

#### Which issue(s) this PR fixes:
Command "kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'consolidation delete' | jq '.'" gives empty output. 2. After running "kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter -f | jq '.'" there is no information provided on how to come out of flow logs and execute next commands.

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
