### PR TITLE
Update aws-lb-controller.md

### DIFF
--- a/website/docs/fundamentals/exposing/aws-lb-controller.md
+++ b/website/docs/fundamentals/exposing/aws-lb-controller.md
@@ -14,7 +14,7 @@ Application Load Balancers work at `L7` of the OSI model, allowing you to expose
 
 The controller enables you to simplify operations and save costs by sharing an Application Load Balancer across multiple applications in your Kubernetes cluster.
 
-The AWS Load Balancer Controller has already been installed in our cluster, so we can get started creating resources.
+The steps to install the AWS Load Balancer Controller will be presented in the subsequent section, enabling you to get started with creating Load Balancer resources in AWS.
 
 :::info
 The AWS Load Balancer Controller was formerly named the AWS ALB Ingress Controller.


### PR DESCRIPTION
AWS Load Balancer controller is not pre-installed with the lab environment. This step is mis-leading. Updated the documentation to reflect the true state

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
