### PR TITLE
fix: No empty line at end of terminal copy

### DIFF
--- a/website/src/components/Terminal/index.tsx
+++ b/website/src/components/Terminal/index.tsx
@@ -150,7 +150,7 @@ class TerminalSection {
 }
 
 function triggerCopy(text: string) {
-  navigator.clipboard.writeText(text);
+  navigator.clipboard.writeText(text.trim());
 
   window.parent.postMessage(`eks-workshop-terminal:${text}`, "*");
 }


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

Currently the button used to copy all the commands in a terminal window adds an extra empty line at the end, which is confusing when using the VSCode IDE. This PR removes any empty space before/after content copied from the terminal.

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
