### PR TITLE
update: Install ACK with helm chart

### DIFF
--- a/manifests/modules/automation/controlplanes/ack/.workshop/cleanup.sh
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/cleanup.sh
@@ -3,3 +3,5 @@
 logmessage "Deleting resources created by ACK..."
 
 delete-all-if-crd-exists tables.dynamodb.services.k8s.aws
+
+uninstall-helm-chart ack-dynamodb ack-dynamodb-dynamodb-chart

--- a/manifests/modules/automation/controlplanes/ack/.workshop/cleanup.sh
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/cleanup.sh
@@ -4,4 +4,4 @@ logmessage "Deleting resources created by ACK..."
 
 delete-all-if-crd-exists tables.dynamodb.services.k8s.aws
 
-uninstall-helm-chart ack-dynamodb ack-dynamodb-dynamodb-chart
+uninstall-helm-chart ack-dynamodb ack-dynamodb-chart

--- a/manifests/modules/automation/controlplanes/ack/.workshop/terraform/main.tf
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/terraform/main.tf
@@ -19,29 +19,6 @@ data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.virginia
 }
 
-#This module installs the ACK controller for DynamoDB through the AWS EKS Addons for ACK
-module "dynamodb_ack_addon" {
-
-  source  = "aws-ia/eks-ack-addons/aws"
-  version = "2.2.0"
-
-  # Cluster Info
-  cluster_name      = var.addon_context.eks_cluster_id
-  cluster_endpoint  = var.addon_context.aws_eks_cluster_endpoint
-  oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
-
-  ecrpublic_username = data.aws_ecrpublic_authorization_token.token.user_name
-  ecrpublic_token    = data.aws_ecrpublic_authorization_token.token.password
-
-  # Controllers to enable
-  enable_dynamodb = true
-  dynamodb = {
-    role_name            = "${var.addon_context.eks_cluster_id}-ack-ddb"
-    role_name_use_prefix = false
-  }
-
-  tags = var.tags
-}
 
 module "iam_assumable_role_carts" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"

--- a/manifests/modules/automation/controlplanes/ack/.workshop/terraform/outputs.tf
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/terraform/outputs.tf
@@ -2,6 +2,7 @@ output "environment_variables" {
   description = "Environment variables to be added to the IDE shell"
   value = {
     CARTS_IAM_ROLE = module.iam_assumable_role_carts.iam_role_arn,
-    DYNAMODB_POLICY_ARN = aws_iam_policy.carts_dynamo.arn
+    DYNAMODB_POLICY_ARN = aws_iam_policy.ack_dynamo.arn
+    ACK_IAM_ROLE=module.iam_assumable_role_ack.iam_role_arn,
   }
 }

--- a/manifests/modules/automation/controlplanes/ack/.workshop/terraform/outputs.tf
+++ b/manifests/modules/automation/controlplanes/ack/.workshop/terraform/outputs.tf
@@ -1,6 +1,7 @@
 output "environment_variables" {
   description = "Environment variables to be added to the IDE shell"
   value = {
-    CARTS_IAM_ROLE = module.iam_assumable_role_carts.iam_role_arn
+    CARTS_IAM_ROLE = module.iam_assumable_role_carts.iam_role_arn,
+    DYNAMODB_POLICY_ARN = aws_iam_policy.carts_dynamo.arn
   }
 }

--- a/website/docs/automation/controlplanes/ack/how-it-works.md
+++ b/website/docs/automation/controlplanes/ack/how-it-works.md
@@ -3,14 +3,6 @@ title: "How does ACK work?"
 sidebar_position: 5
 ---
 
-Each AWS Controller for Kubernetes (ACK) is packaged as a separate container image, published in a public repository corresponding to an individual ACK service controller. To provision resources for a specific AWS service, the corresponding controller must be installed in the Amazon EKS cluster. We've already completed this step in the `prepare-environment` phase. Official container images and Helm charts for ACK are available [here](https://gallery.ecr.aws/aws-controllers-k8s).
-
-In this workshop section, we'll be working with Amazon DynamoDB. The ACK controller for DynamoDB has been pre-installed in the cluster, running as a deployment in its own Kubernetes namespace. To examine the deployment details, run the following command:
-
-```bash
-$ kubectl describe deployment ack-dynamodb -n ack-dynamodb
-```
-
 :::info
 kubectl also provides useful `-oyaml` and `-ojson` flags which extract the full YAML or JSON manifests of the deployment definition, respectively, instead of the formatted output.
 :::

--- a/website/docs/automation/controlplanes/ack/index.md
+++ b/website/docs/automation/controlplanes/ack/index.md
@@ -31,6 +31,6 @@ While the sample application can run entirely within your cluster, including sta
 
 In this lab, we'll use ACK to provision these services and create secrets and configmaps containing the binding information to connect the application to these AWS managed services.
 
-For learning purpose, we're using helm to install the ACK controller. Another option is to use Terraform that allows for rapid deployment of AWS Service Controllers to your cluster. For more information, see the [ACK Terraform module documentation](https://registry.terraform.io/modules/aws-ia/eks-ack-addons/aws/latest#module_dynamodb).
+For learning purposes, we're using helm to install the ACK controller. Another option is to use Terraform that allows for rapid deployment of AWS Service Controllers to your cluster. For more information, see the [ACK Terraform module documentation](https://registry.terraform.io/modules/aws-ia/eks-ack-addons/aws/latest#module_dynamodb).
 
 ![EKS with DynamoDB](./assets/eks-workshop-ddb.webp)

--- a/website/docs/automation/controlplanes/ack/index.md
+++ b/website/docs/automation/controlplanes/ack/index.md
@@ -31,6 +31,6 @@ While the sample application can run entirely within your cluster, including sta
 
 In this lab, we'll use ACK to provision these services and create secrets and configmaps containing the binding information to connect the application to these AWS managed services.
 
-It's worth noting that during the provisioning process, we're using the new ACK Terraform module, which allows for rapid deployment of AWS Service Controllers to your cluster. For more information, see the [ACK Terraform module documentation](https://registry.terraform.io/modules/aws-ia/eks-ack-addons/aws/latest#module_dynamodb).
+For learning purpose, we're using helm to install the ACK controller. Another option is to use Terraform that allows for rapid deployment of AWS Service Controllers to your cluster. For more information, see the [ACK Terraform module documentation](https://registry.terraform.io/modules/aws-ia/eks-ack-addons/aws/latest#module_dynamodb).
 
 ![EKS with DynamoDB](./assets/eks-workshop-ddb.webp)

--- a/website/docs/automation/controlplanes/ack/index.md
+++ b/website/docs/automation/controlplanes/ack/index.md
@@ -17,7 +17,6 @@ $ prepare-environment automation/controlplanes/ack
 This will make the following changes to your lab environment:
 
 - Install the AWS Controllers for DynamoDB in the Amazon EKS cluster
-- Install the AWS Load Balancer controller in the Amazon EKS cluster
 
 You can view the Terraform that applies these changes [here](https://github.com/VAR::MANIFESTS_OWNER/VAR::MANIFESTS_REPOSITORY/tree/VAR::MANIFESTS_REF/manifests/modules/automation/controlplanes/ack/.workshop/terraform).
 

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 Each ACK service controller is packaged into a separate container image that is published in a public repository corresponding to an individual ACK service controller. For each AWS service that we wish to provision, resources for the corresponding controller must be installed in the Amazon EKS cluster. Helm charts and official container images for ACK are available [here](https://gallery.ecr.aws/aws-controllers-k8s).
 
-In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a rols with proper permision is created for the ACK controller. Now let's create a service account and associate it the role.
+In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a role with proper permision is created for the ACK controller. Now let's create a service account and associate it with that role.
 ```bash
 $ kubectl create sa ack-ddb-sa --namespace ack-dynamodb
 $ kubectl annotate serviceaccount -n  ack-dynamodb ack-ddb-sa \

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -5,8 +5,7 @@ sidebar_position: 3
 
 Each ACK service controller is packaged into a separate container image that is published in a public repository corresponding to an individual ACK service controller. For each AWS service that we wish to provision, resources for the corresponding controller must be installed in the Amazon EKS cluster. Helm charts and official container images for ACK are available [here](https://gallery.ecr.aws/aws-controllers-k8s).
 
-In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller first by using helm chart.
-As we ran the prepare-environment earlier, a policy is created for ACK controller:
+In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a policy is created for the ACK controller.
 ```bash
 $ aws iam get-policy --policy-arn $DYNAMODB_POLICY_ARN
 ```

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -1,0 +1,37 @@
+---
+title: "Introduction"
+sidebar_position: 3
+---
+
+Each ACK service controller is packaged into a separate container image that is published in a public repository corresponding to an individual ACK service controller. For each AWS service that we wish to provision, resources for the corresponding controller must be installed in the Amazon EKS cluster. Helm charts and official container images for ACK are available [here](https://gallery.ecr.aws/aws-controllers-k8s).
+
+In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller first by using helm chart.
+As we ran the prepare-environment earlier, a policy is created for ACK controller:
+```bash
+$ aws iam get-policy --policy-arn $DYNAMODB_POLICY_ARN
+```
+Then we will create an IRSA for the ACK cntroller to use: 
+```bash
+$ eksctl create iamserviceaccount --name ack-ddb-sa \
+  --namespace ack-dynamodb --cluster $EKS_CLUSTER_NAME \
+  --role-name ${EKS_CLUSTER_NAME}-ack-controller \
+  --attach-policy-arn $DYNAMODB_POLICY_ARN --approve
+```
+
+Next, lets install the DynamoDB ACK controller by using the following commends: 
+```bash
+$ aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
+$ helm install -n ack-dynamodb ack-dynamodb --create-namespace \
+  oci://public.ecr.aws/aws-controllers-k8s/dynamodb-chart \
+  --version=1.1.1  \
+  --set=aws.region=$AWS_REGION \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=ack-ddb-sa
+```
+
+Once the controller is installed, it is running as a deployment in ack-dynamodb namespace. To see what's under the hood, lets run the below.
+
+```bash
+$ kubectl get deployment  -n ack-dynamodb
+```
+

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -5,21 +5,17 @@ sidebar_position: 3
 
 Each ACK service controller is packaged into a separate container image that is published in a public repository corresponding to an individual ACK service controller. For each AWS service that we wish to provision, resources for the corresponding controller must be installed in the Amazon EKS cluster. Helm charts and official container images for ACK are available [here](https://gallery.ecr.aws/aws-controllers-k8s).
 
-In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a policy is created for the ACK controller.
+In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a rols with proper permision is created for the ACK controller. Now let's create a service account and associate it the role.
 ```bash
-$ aws iam get-policy --policy-arn $DYNAMODB_POLICY_ARN
-```
-Then we will create an IRSA for the ACK controller to use: 
-```bash
-$ eksctl create iamserviceaccount --name ack-ddb-sa \
-  --namespace ack-dynamodb --cluster $EKS_CLUSTER_NAME \
-  --role-name ${EKS_CLUSTER_NAME}-ack-controller \
-  --attach-policy-arn $DYNAMODB_POLICY_ARN --approve
+$ kubectl create sa --name ack-ddb-sa --namespace ack-dynamodb
+$ kubectl annotate serviceaccount -n  ack-dynamodb ack-ddb-sa \
+  eks.amazonaws.com/role-arn=$ACK_IAM_ROLE --overwrite
 ```
 
-Next, lets install the DynamoDB ACK controller by using the following commends: 
+Next, let us install the DynamoDB ACK controller by using the following commends: 
 ```bash
-$ aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
+$ aws ecr-public get-login-password --region us-east-1 | \
+helm registry login --username AWS --password-stdin public.ecr.aws
 $ helm install -n ack-dynamodb ack-dynamodb --create-namespace \
   oci://public.ecr.aws/aws-controllers-k8s/dynamodb-chart \
   --version=1.1.1  \

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -7,6 +7,7 @@ Each ACK service controller is packaged into a separate container image that is 
 
 In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a role with proper permision is created for the ACK controller. Now let's create a service account and associate it with that role.
 ```bash
+$ kubectl create ns ack-dynamodb
 $ kubectl create sa ack-ddb-sa --namespace ack-dynamodb
 $ kubectl annotate serviceaccount -n  ack-dynamodb ack-ddb-sa \
   eks.amazonaws.com/role-arn=$ACK_IAM_ROLE --overwrite
@@ -16,7 +17,7 @@ Next, let us install the DynamoDB ACK controller by using the following commends
 ```bash
 $ aws ecr-public get-login-password --region us-east-1 | \
 helm registry login --username AWS --password-stdin public.ecr.aws
-$ helm install -n ack-dynamodb ack-dynamodb --create-namespace \
+$ helm install -n ack-dynamodb ack  \
   oci://public.ecr.aws/aws-controllers-k8s/dynamodb-chart \
   --version=1.1.1  \
   --set=aws.region=$AWS_REGION \

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -9,7 +9,7 @@ In this section, since we will be working with Amazon DynamoDB ACK, we first nee
 ```bash
 $ aws iam get-policy --policy-arn $DYNAMODB_POLICY_ARN
 ```
-Then we will create an IRSA for the ACK cntroller to use: 
+Then we will create an IRSA for the ACK controller to use: 
 ```bash
 $ eksctl create iamserviceaccount --name ack-ddb-sa \
   --namespace ack-dynamodb --cluster $EKS_CLUSTER_NAME \

--- a/website/docs/automation/controlplanes/ack/introduction.md
+++ b/website/docs/automation/controlplanes/ack/introduction.md
@@ -7,7 +7,7 @@ Each ACK service controller is packaged into a separate container image that is 
 
 In this section, since we will be working with Amazon DynamoDB ACK, we first need to install the ACK controller by using the Helm chart. As we ran the prepare-environment earlier, a rols with proper permision is created for the ACK controller. Now let's create a service account and associate it the role.
 ```bash
-$ kubectl create sa --name ack-ddb-sa --namespace ack-dynamodb
+$ kubectl create sa ack-ddb-sa --namespace ack-dynamodb
 $ kubectl annotate serviceaccount -n  ack-dynamodb ack-ddb-sa \
   eks.amazonaws.com/role-arn=$ACK_IAM_ROLE --overwrite
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR added a web page that illustrates how to install the ACK DynanmoDB controller via helm chart. It also removed a section of  terraform file related to installing the ACK controller. It will give users more insight in to what is being done.

#### Which issue(s) this PR fixes:
This PR solves part of the #863 issue (Changes to labs to manually install relevant components), specifically the section  [Automation] ACK - Install ACK via the helm charts. 

Fixes #
It fixes the description on the page of How does ACK work. 

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
