### PR TITLE
fix: replace deprecated argon-cli npm package with argon2

### DIFF
--- a/lab/cfn/eks-workshop-vscode-cfn.yaml
+++ b/lab/cfn/eks-workshop-vscode-cfn.yaml
@@ -281,7 +281,7 @@ Resources:
                 - !Sub |
                   set -e
 
-                  yum install -y git tar gzip vim nodejs npm make gcc g++
+                  yum install -y git tar gzip vim nodejs npm make gcc g++ argon2
 
                   export environment="${Environment}"
 
@@ -329,7 +329,7 @@ Resources:
 
                   PASSWORD_SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id "${EksWorkshopIdePassword.Id}" --query 'SecretString' --output text)
                   IDE_PASSWORD=$(echo "$PASSWORD_SECRET_VALUE" | jq -r '.password')
-                  HASHED_PASSWORD=$(echo -n "$IDE_PASSWORD" | npx argon2-cli -e)
+                  HASHED_PASSWORD=$(echo -n "$IDE_PASSWORD" | argon2 saltItWithSalt -l 32 -e)
 
                   mkdir -p ~/.config/code-server
                   touch ~/.config/code-server/config.yaml


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:
Replaces deprecated npm package argo2-cli to argon2 cli tool. The cf installer fails, because argo2-cli returns an error, and it is deprecated anyway, so it needs replacement:  https://www.npmjs.com/package/argon2-cli

#### Which issue(s) this PR fixes:
https://github.com/aws-samples/eks-workshop-v2/issues/1181

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
