### PR TITLE
fix: remove unnecessary use of `tr` in access-opensearch.md

### DIFF
--- a/website/docs/observability/opensearch/access-opensearch.md
+++ b/website/docs/observability/opensearch/access-opensearch.md
@@ -10,13 +10,13 @@ Credentials for the OpenSearch domain have been saved in the AWS Systems Manager
 ```bash
 $ export OPENSEARCH_HOST=$(aws ssm get-parameter \
       --name /eksworkshop/$EKS_CLUSTER_NAME/opensearch/host \
-      --region $AWS_REGION | jq .Parameter.Value | tr -d '"')
+      --region $AWS_REGION | jq -r .Parameter.Value)
 $ export OPENSEARCH_USER=$(aws ssm get-parameter \
       --name /eksworkshop/$EKS_CLUSTER_NAME/opensearch/user  \
-      --region $AWS_REGION --with-decryption | jq .Parameter.Value | tr -d '"')
+      --region $AWS_REGION --with-decryption | jq -r .Parameter.Value)
 $ export OPENSEARCH_PASSWORD=$(aws ssm get-parameter \
       --name /eksworkshop/$EKS_CLUSTER_NAME/opensearch/password \
-      --region $AWS_REGION --with-decryption | jq .Parameter.Value | tr -d '"')
+      --region $AWS_REGION --with-decryption | jq -r .Parameter.Value)
 $ export OPENSEARCH_DASHBOARD_FILE=~/environment/eks-workshop/modules/observability/opensearch/opensearch-dashboards.ndjson
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes the unneccesary and potentially destructive use of `tr -d '"'` to remove enclosing double-quotes from a json-string.

#### Which issue(s) this PR fixes:

This might be destructive, because tr will remove *all* quotes, not only the enclosing ones and will not honor JSON escaped quotes.

Check:

`jq -cn '$ARGS.named' --arg test 'string_with"quotes"' | jq .test | tr -d '"'`

vs

`jq -cn '$ARGS.named' --arg test 'string_with"quotes"' | jq -r .test`

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
