### PR TITLE
fix: Skip final RDS snapshot in SG for Pods

### DIFF
--- a/manifests/modules/networking/securitygroups-for-pods/.workshop/terraform/preprovision/main.tf
+++ b/manifests/modules/networking/securitygroups-for-pods/.workshop/terraform/preprovision/main.tf
@@ -48,6 +48,7 @@ module "catalog_mysql" {
   maintenance_window = "Mon:00:00-Mon:03:00"
   backup_window      = "03:00-06:00"
 
+  skip_final_snapshot     = true
   backup_retention_period = 0
 
   tags = var.tags


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

There seems to be cases where the RDS final snapshot gets created when cleaning up the SG for Pods lab due to missing IAM permissions. This does not seem to happen in the automated tests.

This PR explicitly disables the final snapshot instead of changing the IAM permissions.

#### Which issue(s) this PR fixes:

Fixes #1201

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
