### PR TITLE
fix: `make serve` does not build docusaurus site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ glob='-'
 install:
 	yarn install
 
+.PHONY: build
+build: install
+	yarn build
+
 .PHONY: serve
-serve: install
+serve: build
 	yarn serve
 
 .PHONY: tf-fmt

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "releaser"
   ],
   "scripts": {
+    "build": "yarn workspace website build",
     "serve": "yarn workspace website serve",
     "spelling:check": "yarn cspell 'website/docs/**/*.md'",
     "links:check": "markdown-link-check -q -c link-check-config.json website/docs/**/*.md",


### PR DESCRIPTION
Fixes #1219

Add a Make target for `build` that `serve` depends on so the site gets built first.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

docs/authoring_content.md does not result in a working site

#### Which issue(s) this PR fixes:

Fixes #1219 

#### Quality checks

- [ x ] My content adheres to the style guidelines
- [ n/a ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
