### PR TITLE
fix: Now need to install CRDs in VPC Lattice lab

### DIFF
--- a/website/docs/networking/vpc-lattice/setup.md
+++ b/website/docs/networking/vpc-lattice/setup.md
@@ -31,9 +31,10 @@ $ aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --ip-permissio
 }
 ```
 
-This step will install the controller and the CRDs (Custom Resource Definitions) required to interact with the Kubernetes Gateway API.
+This step will install the Kubernetes Gateway API CRDs as well as the VPC Lattice controller that provide an implementation of that API:
 
 ```bash wait=30
+$ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
 $ aws ecr-public get-login-password --region us-east-1 \
   | helm registry login --username AWS --password-stdin public.ecr.aws
 $ helm install gateway-api-controller \


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

Updating the VPC Lattice controller to 1.1.0 requires that we separately install the Gateway API CRDs.

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
