### PR TITLE
chore: Get eksctl from eksctlio

### DIFF
--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -9,7 +9,7 @@ kubectl_version='1.31.3'
 helm_version='3.16.4'
 
 # renovate: depName=eksctl-io/eksctl
-eksctl_version='0.197.0'
+eksctl_version='0.202.0'
 
 kubeseal_version='0.18.4'
 
@@ -87,7 +87,7 @@ mv ./linux-${arch_name}/helm /usr/local/bin
 rm -rf linux-${arch_name}/ helm.tar.gz
 
 # eksctl
-download "https://github.com/weaveworks/eksctl/releases/download/v$eksctl_version/eksctl_Linux_${arch_name}.tar.gz" "eksctl.tar.gz"
+download "https://github.com/eksctl-io/eksctl/releases/download/v${eksctl_version}/eksctl_Linux_${arch_name}.tar.gz" "eksctl.tar.gz"
 tar zxf eksctl.tar.gz
 chmod +x eksctl
 mv ./eksctl /usr/local/bin


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:
This change pulls eksctl from it's new home on eksctl.io and updates it to 0.202.0

#### Which issue(s) this PR fixes:

None, sorry :)

#### Quality checks

Tested using `make create-infrastructure` and `make destroy-infrastructure`
Happy to run additional tests.

- [x ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
