### PR TITLE
feat: Banner promotions on eksworkshop.com homepage

### DIFF
--- a/website/src/components/HomepageBanner/index.js
+++ b/website/src/components/HomepageBanner/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './styles.module.css';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+
+const HomepageBanner = () => {
+  return (
+    <div className={styles.banner}>
+      <span className={styles.bannerText}>
+      Simplify Kubernetes with <b>Amazon EKS Auto Mode</b>:{" "}
+        <a 
+          href="https://aws-experience.com/emea/smb/events/series/simplifying-kubernetes-operations-with-amazon-eks-auto-mode?trk=e3d0398c-e0e9-4665-af82-a2e8124a6db8&sc_channel=el"
+          target="_blank"
+        >
+          Webinar <FontAwesomeIcon
+            icon={faArrowUpRightFromSquare}
+            className={styles.linkIcon}
+          />
+        </a>
+      </span>
+    </div>
+  );
+};
+
+export default HomepageBanner;

--- a/website/src/components/HomepageBanner/styles.module.css
+++ b/website/src/components/HomepageBanner/styles.module.css
@@ -1,0 +1,11 @@
+.banner {
+  background-color: #FF9900;
+  padding: 8px;
+  text-align: center;
+  width: 100%;
+}
+
+.bannerText {
+  color: #FFFFFF;
+  font-size: 16px;
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -5,6 +5,7 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
 import HomepageVideo from "@site/src/components/HomepageVideo";
+import HomepageBanner from "@site/src/components/HomepageBanner";
 
 import styles from "./index.module.css";
 
@@ -37,6 +38,7 @@ export default function Home() {
     >
       <HomepageHeader />
       <main>
+        <HomepageBanner />
         <HomepageFeatures />
         <HomepageVideo />
       </main>


### PR DESCRIPTION
Adding a homepage promotion banner to promote EKS-related events on the eksworkshop.com home page. Should not affect in-person events.

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
