### PR TITLE
fix: Update wording on Linx 62 for configuring-graviton.md to reference correct command

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/graviton/configuring-graviton.md
+++ b/website/docs/fundamentals/managed-node-groups/graviton/configuring-graviton.md
@@ -59,7 +59,7 @@ ip-192-168-19-31.us-west-2.compute.internal   Ready    <none>   6h56m  vVAR::KUB
 ip-10-42-172-231.us-west-2.compute.internal   Ready    <none>   2m5s   vVAR::KUBERNETES_NODE_VERSION     graviton    arm64
 ```
 
-The above command makes use of the `--selector` flag to query for all nodes that have a label of `eks.amazonaws.com/nodegroup` that matches the name of our managed node group `graviton`. The `--label-columns` flag also allows us to display the value of the `eks.amazonaws.com/nodegroup` label as well as the processor architecture in the output. Note that the `ARCH` column shows our tainted node group running Graviton `arm64` processors.
+The below command makes use of the `--selector` flag to query for all nodes that have a label of `eks.amazonaws.com/nodegroup` that matches the name of our managed node group `graviton`. The `--label-columns` flag also allows us to display the value of the `eks.amazonaws.com/nodegroup` label as well as the processor architecture in the output. Note that the `ARCH` column shows our tainted node group running Graviton `arm64` processors.
 
 Let's explore the current configuration of our node. The following command will list the details of all nodes that are part of our managed node group.
 


### PR DESCRIPTION
Line 62: "The above command..." needs to be modified to reference "The below command..." - otherwise need to modify this section accordingly. 

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
