### PR TITLE
fix: Add missing description to frontmatter for EKS Hybrid Nodes module

### DIFF
--- a/website/docs/networking/eks-hybrid-nodes/index.md
+++ b/website/docs/networking/eks-hybrid-nodes/index.md
@@ -3,6 +3,7 @@ title: "Amazon EKS Hybrid Nodes"
 sidebar_position: 50
 sidebar_custom_props: { "module": true }
 weight: 10 # used by test framework
+description: "Amazon EKS Hybrid Nodes unifies management of Kubernetes across cloud, on premises, and edge environments, driving higher scalability, availability, and efficiency."
 ---
 
 ::required-time{estimatedLabExecutionTimeMinutes="30"}


### PR DESCRIPTION
EKS Hybrid Nodes module preview was showing ::required-time because the description frontmatter is missing.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
