### PR TITLE
fix: EKS Hybrid Nodes Role

### DIFF
--- a/lab/cfn/eks-workshop-vscode-cfn.yaml
+++ b/lab/cfn/eks-workshop-vscode-cfn.yaml
@@ -467,6 +467,15 @@ Resources:
       PolicyDocument:
         file: ./iam/policies/labs3.yaml
 
+  EksWorkshopSsmPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Roles:
+        - !Ref EksWorkshopIdeRole
+      ManagedPolicyName: ${Env}-ide-ssm
+      PolicyDocument:
+        file: ./iam/policies/ssm.yaml
+
   EksWorkshopIdeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
VSCode code server uses a different cloudformation than the workshop ide role use for dev. The ssm.yaml permissions were missing for that role.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
