### PR TITLE
chore: Removed old EKS Blueprints Terraform references

### DIFF
--- a/manifests/modules/observability/logging/pods/.workshop/terraform/main.tf
+++ b/manifests/modules/observability/logging/pods/.workshop/terraform/main.tf
@@ -7,10 +7,27 @@ locals {
   cw_log_group_name = "/${var.addon_context.eks_cluster_id}/worker-fluentbit-logs-${random_string.fluentbit_log_group.result}"
 }
 
-module "aws_for_fluentbit" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1//modules/kubernetes-addons/aws-for-fluentbit"
+module "eks_blueprints_addons" {
+  source  = "aws-ia/eks-blueprints-addons/aws"
+  version = "1.20.0"
 
-  cw_log_group_name = local.cw_log_group_name
+  cluster_name      = var.addon_context.eks_cluster_id
+  cluster_endpoint  = var.addon_context.aws_eks_cluster_endpoint
+  cluster_version   = var.eks_cluster_version
+  oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
 
-  addon_context = var.addon_context
+  enable_aws_for_fluentbit = true
+
+  aws_for_fluentbit = {
+    chart_version = "0.1.32"
+
+    role_name   = "${var.addon_context.eks_cluster_id}-fluent-bit"
+    policy_name = "${var.addon_context.eks_cluster_id}-fluent-bit"
+
+    wait = true
+  }
+
+  aws_for_fluentbit_cw_log_group = local.cw_log_group_name
+
+  observability_tag = null
 }

--- a/manifests/modules/observability/oss-metrics/.workshop/terraform/main.tf
+++ b/manifests/modules/observability/oss-metrics/.workshop/terraform/main.tf
@@ -134,27 +134,44 @@ resource "kubernetes_namespace" "grafana" {
   }
 }
 
-module "eks_blueprints_kubernetes_grafana_addon" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.25.0//modules/kubernetes-addons/grafana"
+module "grafana" {
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.1"
 
   depends_on = [
     time_sleep.blueprints_addons_sleep,
     kubernetes_config_map.order_service_metrics_dashboard
   ]
 
-  addon_context = var.addon_context
+  description      = "Grafana"
+  chart            = "grafana"
+  chart_version    = "6.43.1"
+  namespace        = kubernetes_namespace.grafana.metadata[0].name
+  create_namespace = false
+  repository       = "https://grafana.github.io/helm-charts"
+  values           = [local.grafana_values]
+  wait             = true
+  set = [{
+    name  = "serviceAccount.name"
+    value = "grafana"
+  }]
 
-  irsa_policies = [
-    aws_iam_policy.grafana.arn
+  create_role             = true
+  role_name               = "${var.addon_context.eks_cluster_id}-grafana"
+  policy_name             = "${var.addon_context.eks_cluster_id}-grafana"
+  source_policy_documents = [data.aws_iam_policy_document.grafana.json]
+  set_irsa_names = [
+    "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn",
   ]
-
-  helm_config = {
-    create_namespace = false
-    namespace        = kubernetes_namespace.grafana.metadata[0].name
-
-    values = [local.grafana_values]
+  oidc_providers = {
+    this = {
+      provider_arn = var.addon_context.eks_oidc_provider_arn
+      # namespace is inherited from chart
+      service_account = "grafana"
+    }
   }
 }
+
 
 resource "kubernetes_config_map" "order_service_metrics_dashboard" {
   metadata {
@@ -435,6 +452,14 @@ EOF
   }
 }
 
+data "aws_iam_policy_document" "grafana" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["aps:*"]
+  }
+}
+
 resource "aws_iam_policy" "grafana" {
   name = "${var.addon_context.eks_cluster_id}-grafana-other"
 
@@ -454,10 +479,6 @@ resource "aws_iam_policy" "grafana" {
 
 locals {
   grafana_values = <<EOF
-serviceAccount:
-  create: false
-  name: grafana
-
 env:
   AWS_SDK_LOAD_CONFIG: true
   GF_AUTH_SIGV4_AUTH_ENABLED: true


### PR DESCRIPTION
<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

There are still a few modules that use the old v4.X version of EKS Blueprints, which is no longer maintained. This PR migrates these references to either the new blueprints addons repository or installs the chart more directly.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
