### PR TITLE
fix: karpenter log grep updated in Karpenter lab

### DIFF
--- a/website/docs/autoscaling/compute/karpenter/consolidation.md
+++ b/website/docs/autoscaling/compute/karpenter/consolidation.md
@@ -51,7 +51,7 @@ $ kubectl scale -n other deployment/inflate --replicas 5
 We can check the Karpenter logs to get an idea of what actions it took in response to our scaling in the deployment. Wait about 5-10 seconds before running the following command:
 
 ```bash test=false
-$ kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'disrupting nodeclaim(s) via delete' | jq '.'
+$ kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'disrupting node(s)' | jq '.'
 ```
 
 The output will show Karpenter identifying specific nodes to cordon, drain and then terminate:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix for grepping Karpenter logs due to node disruption.

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
