### PR TITLE
fix: test suite checks for karpenter disruption log

### DIFF
--- a/website/docs/autoscaling/compute/karpenter/consolidation.md
+++ b/website/docs/autoscaling/compute/karpenter/consolidation.md
@@ -44,13 +44,13 @@ ip-10-42-9-102.us-west-2.compute.internal    Ready    <none>   14m     vVAR::KUB
 
 Next, scale the number of replicas back down to 5:
 
-```bash
+```bash wait=90
 $ kubectl scale -n other deployment/inflate --replicas 5
 ```
 
 We can check the Karpenter logs to get an idea of what actions it took in response to our scaling in the deployment. Wait about 5-10 seconds before running the following command:
 
-```bash test=false
+```bash hook=grep
 $ kubectl logs -l app.kubernetes.io/instance=karpenter -n karpenter | grep 'disrupting node(s)' | jq '.'
 ```
 

--- a/website/docs/autoscaling/compute/karpenter/tests/hook-grep.sh
+++ b/website/docs/autoscaling/compute/karpenter/tests/hook-grep.sh
@@ -1,0 +1,14 @@
+set -Eeuo pipefail
+
+before() {
+  echo "noop"
+}
+
+after() {
+  if [[ -z "$TEST_OUTPUT" ]]; then
+    echo "Failed to find a disruption log. Expected at least one."
+    exit 1
+  fi
+}
+
+"$@"


### PR DESCRIPTION
#### What this PR does / why we need it:
Test suite now checks for karpenter disruption log. If it changes in the future, test suite should fail.

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
