### PR TITLE
fix: Use delete-all-if-crd-exists for cleanup

### DIFF
--- a/manifests/modules/networking/eks-hybrid-nodes/.workshop/cleanup.sh
+++ b/manifests/modules/networking/eks-hybrid-nodes/.workshop/cleanup.sh
@@ -8,7 +8,7 @@ kubectl delete -k ~/environment/eks-workshop/modules/networking/eks-hybrid-nodes
 
 kubectl delete deployment nginx-deployment --ignore-not-found=true
 
-kubectl delete clusterpolicies.kyverno.io set-pod-deletion-cost --ignore-not-found 
+delete-all-if-crd-exists clusterpolicies.kyverno.io
 
 uninstall-helm-chart cilium cilium
 uninstall-helm-chart kyverno kyverno


### PR DESCRIPTION
The EKS Hybrid nodes module is failing cleanup if the cloud bursting scenario is never run. Using this function fixes that.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

EKS Hybrid Nodes module fails cleanup if the cloud bursting scenario is never run. This is because cleanup was trying to delete a CRD that is not installed.

#### Which issue(s) this PR fixes:

Fixes #1357

#### Quality checks

- [ x] My content adheres to the style guidelines
- [ x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
