### PR TITLE
fix: command is returning error

### DIFF
--- a/website/docs/security/cluster-access-management/managing.md
+++ b/website/docs/security/cluster-access-management/managing.md
@@ -39,7 +39,7 @@ The cluster creator is the entity that actually created the cluster, either via 
 If you describe these access entries you'll be able to see more information:
 
 ```bash
-$ NODE_ROLE=$(aws eks list-access-entries --cluster $EKS_CLUSTER_NAME --output text | awk '/Node/ {print $2}')
+$ NODE_ROLE=$(aws eks list-access-entries --cluster $EKS_CLUSTER_NAME --output text | awk '/NodeInstanceRole/ {print $2}')
 $ aws eks describe-access-entry --cluster $EKS_CLUSTER_NAME --principal-arn $NODE_ROLE
 {
     "accessEntry": {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes a command that is returning an error:

`NODE_ROLE=$(aws eks list-access-entries --cluster $EKS_CLUSTER_NAME --output text | awk '/Node/ {print $2}')
aws eks describe-access-entry --cluster $EKS_CLUSTER_NAME --principal-arn $NODE_ROLE

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: arn:aws:iam::273073574926:role/eksctl-eks-workshop-nodegroup-defa-NodeInstanceRole-jD2CUSiBTxMD`

The aws command returns 2 roles arn and it causes the error:

`aws eks list-access-entries --cluster $EKS_CLUSTER_NAME --output text | awk '/Node/ {print $2}'
arn:aws:iam:::role/eksctl-eks-workshop-cluster-HybridNodesSSMRole-gTfzyVPtHaSA
arn:aws:iam:::role/eksctl-eks-workshop-nodegroup-defa-NodeInstanceRole-jD2CUSiBTxMD`

It is fixed by passing a more concrete filter. 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
