### PR TITLE
docs: Update ascp.md

### DIFF
--- a/website/docs/security/secrets-management/secrets-manager/ascp.md
+++ b/website/docs/security/secrets-management/secrets-manager/ascp.md
@@ -10,7 +10,7 @@ Let's validate that the addons were deployed correctly.
 First, check the Secret Store CSI driver `DaemonSet` and its `Pods`:
 
 ```bash
-$ kubectl -n secrets-store-csi-driver get pods,daemonsets -l app=secrets-store-csi-driver
+$ kubectl -n kube-system get pods,daemonsets -l app=secrets-store-csi-driver
 NAME                                                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
 daemonset.apps/csi-secrets-store-secrets-store-csi-driver   3         3         3       3            3           kubernetes.io/os=linux   3m57s
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The command shown in the docs assumes the secrets store csi driver is installed in a namespace that is wrong. The driver is currently installed in kube-system namespace. 

#### Which issue(s) this PR fixes:

https://github.com/aws-samples/eks-workshop-v2/issues/1446

Fixes #

Changed the namespace in the command. 

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
