### PR TITLE
docs: Added YAML file explanations for 'Run pods on Graviton' section

### DIFF
--- a/website/docs/fundamentals/managed-node-groups/graviton/scheduling-graviton.md
+++ b/website/docs/fundamentals/managed-node-groups/graviton/scheduling-graviton.md
@@ -38,6 +38,7 @@ Let's update our `ui` deployment to bind its pods to our tainted managed node gr
 modules/fundamentals/mng/graviton/nodeselector-wo-toleration/deployment.yaml
 Deployment/ui
 ```
+In the above manifest, the `nodeSelector` specifies that pods should only be scheduled on nodes with the label `kubernetes.io/arch: arm64`. This `nodeSelector` effectively restricts the UI pods to run only on ARM64 architecture nodes (Graviton nodes).
 
 To apply the Kustomize changes run the following command:
 
@@ -96,6 +97,12 @@ To fix this, we need to add a toleration. Let's ensure our deployment and associ
 modules/fundamentals/mng/graviton/nodeselector-w-toleration/deployment.yaml
 Deployment/ui
 ```
+This YAML builds upon the previous configuration by adding a toleration. The `tolerations` section allows the pod to be scheduled on nodes with the `frontend` taint as explained below:
+- `key: "frontend"` specifies the taint key to tolerate.
+- `operator: "Exists"` means the pod will tolerate the taint regardless of its value.
+- `effect: "NoExecute"` matches the taint effect, allowing the pod to run on nodes with this taint.
+
+The nodeSelector remains the same, ensuring pods run only on ARM64 architecture nodes. To apply the Kustomize changes run the following command:
 
 ```bash
 $ kubectl apply -k ~/environment/eks-workshop/modules/fundamentals/mng/graviton/nodeselector-w-toleration/


### PR DESCRIPTION
Added explanations for both yaml files present in this below document:
[Managed Node Groups](https://www.eksworkshop.com/docs/fundamentals/managed-node-groups/) > [Graviton (ARM) instances](https://www.eksworkshop.com/docs/fundamentals/managed-node-groups/graviton/) > Run pods on Graviton

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:
Adding YAML explainers helps learners better understand the configurations being applied

#### Which issue(s) this PR fixes:
Related to https://github.com/aws-samples/eks-workshop-v2/issues/1391

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
