### PR TITLE
Update external-dns.md for new line after output

### DIFF
--- a/website/docs/fundamentals/exposing/ingress/external-dns.md
+++ b/website/docs/fundamentals/exposing/ingress/external-dns.md
@@ -77,7 +77,7 @@ Route 53 private hosted zones are only accessible from associated VPCs, in this 
 
 ```bash hook=dns-curl
 $ kubectl -n ui exec -it \
-  deployment/ui -- curl -i http://ui.retailstore.com/actuator/health/liveness
+  deployment/ui -- bash -c "curl -i http://ui.retailstore.com/actuator/health/liveness; echo"
 
 HTTP/1.1 200 OK
 Date: Thu, 24 Apr 2025 07:45:12 GMT


### PR DESCRIPTION
```
ec2-user:~/environment:$ kubectl -n ui exec -it \
  deployment/ui -- curl -i http://ui.retailstore.com/actuator/health/liveness
HTTP/1.1 200 OK
Date: Wed, 11 Jun 2025 15:22:58 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Content-Length: 15
Connection: keep-alive
Set-Cookie: SESSIONID=8a73565b-efe1-4ecf-9fa8-8f3efce7e2e4

{"status":"UP"}ec2-user:
```

updated to:

```
ec2-user:~/environment:$ kubectl -n ui exec -it \
  deployment/ui -- bash -c "curl -i http://ui.retailstore.com/actuator/health/liveness; echo"
HTTP/1.1 200 OK
Date: Wed, 11 Jun 2025 15:31:30 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Content-Length: 15
Connection: keep-alive
Set-Cookie: SESSIONID=ce1b998f-b9c0-4865-8316-99f6e1ac6566

{"status":"UP"}
ec2-user:~/environment:$ 
```

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [X] My content adheres to the style guidelines
- [ ] [N/A - Not a module change] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
