### PR TITLE
fix: correct code-terminal in smart mode

### DIFF
--- a/website/src/remark/code-terminal.js
+++ b/website/src/remark/code-terminal.js
@@ -8,7 +8,7 @@ const plugin = (options) => {
       if (node.lang === "bash") {
         const value = node.value;
 
-        const smartMode = false;
+        var smartMode = false;
         var m;
 
         if (node.meta) {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes a runtime error in the code-terminal remark plugin caused by attempting to reassign a const variable. Specifically, the `smartMode` flag was initially declared using `const` and later reassigned based on parsed metadata. The declaration has been updated to use `var` instead, allowing reassignment and restoring correct plugin behavior.

#### Which issue(s) this PR fixes:

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
