### PR TITLE
feat: Add dismissable notification with configurable content

### DIFF
--- a/website/src/components/GlobalNotification/index.js
+++ b/website/src/components/GlobalNotification/index.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import styles from './styles.module.css';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowUpRightFromSquare, faTimes } from "@fortawesome/free-solid-svg-icons";
+import notificationConfig from '../../config/notification.json';
+
+const GlobalNotification = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // Don't render if notification is disabled in config
+  if (!notificationConfig.enabled) return null;
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem('eks-workshop-notification-dismissed');
+    if (!dismissed) {
+      setIsVisible(true);
+      setTimeout(() => setIsAnimating(true), 100);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setIsAnimating(false);
+    setTimeout(() => {
+      setIsVisible(false);
+      localStorage.setItem('eks-workshop-notification-dismissed', 'true');
+    }, 300);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className={`${styles.notification} ${isAnimating ? styles.notificationVisible : ''}`}>
+      <span className={styles.notificationText}>
+        <b>{notificationConfig.prefix}</b> {notificationConfig.text}{" "}
+        <a 
+          href={notificationConfig.linkUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {notificationConfig.linkText} <FontAwesomeIcon
+            icon={faArrowUpRightFromSquare}
+            className={styles.linkIcon}
+          />
+        </a>
+      </span>
+      <button 
+        className={styles.dismissButton}
+        onClick={handleDismiss}
+        aria-label="Dismiss notification"
+      >
+        <FontAwesomeIcon icon={faTimes} />
+      </button>
+    </div>
+  );
+};
+
+export default GlobalNotification;

--- a/website/src/components/GlobalNotification/styles.module.css
+++ b/website/src/components/GlobalNotification/styles.module.css
@@ -1,0 +1,79 @@
+.notification {
+  background-color: #1a1a1a;
+  padding: 12px 16px;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  z-index: 1000;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  max-width: 400px;
+  min-width: 300px;
+  transform: translateX(100%);
+  opacity: 0;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.notificationVisible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.notificationText {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 400;
+  flex: 1;
+  margin-right: 12px;
+}
+
+.notificationText b {
+  color: #ffffff;
+}
+
+.notificationText a {
+  color: #ff9900;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.notificationText a:hover {
+  color: #ffb84d;
+  text-decoration: underline;
+}
+
+.linkIcon {
+  font-size: 12px;
+  width: 12px;
+  height: 12px;
+  margin-left: 4px;
+  vertical-align: middle;
+  display: inline-block;
+}
+
+.dismissButton {
+  background: none;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.dismissButton:hover {
+  background-color: rgba(255,255,255,0.1);
+  opacity: 1;
+}
+

--- a/website/src/config/notification.json
+++ b/website/src/config/notification.json
@@ -1,0 +1,7 @@
+{
+  "enabled": false,
+  "prefix": "Live:",
+  "text": "Hands-on EKS Workshop Series -",
+  "linkText": "Register",
+  "linkUrl": "https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=d42ffbaa-d60a-4513-8a79-0bf36b9f33ce&sc_channel=el"
+}

--- a/website/src/theme/Root/index.js
+++ b/website/src/theme/Root/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import GlobalNotification from '../../components/GlobalNotification';
+
+export default function Root({children}) {
+  return (
+    <>
+      <GlobalNotification />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Used for CTAs, only appears on eksworkshop.com. Configured to be false by default. Only needs to be dismissed once. On stable branch, we update `website/src/config/notification.json` to have `enabled: true`

<img width="436" alt="image" src="https://github.com/user-attachments/assets/62e60ee3-0989-4319-82e3-a76ef7fde1b2" />


#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
