### PR TITLE
fix: Adding alb reload after permissions fix for Troubleshooting ALB scenario

### DIFF
--- a/lab/iam/policies/troubleshoot.yaml
+++ b/lab/iam/policies/troubleshoot.yaml
@@ -87,3 +87,14 @@ Statement:
     Condition:
       StringEquals:
         aws:ResourceTag/eks:nodegroup-name: "new_nodegroup_3"
+
+  - Effect: Allow
+    Action:
+      - cloudformation:CreateStack
+      - cloudformation:UpdateStack
+      - cloudformation:DeleteStack
+      - cloudformation:DescribeStacks
+      - cloudformation:DescribeStackEvents
+      - cloudformation:DescribeStackResources
+      - cloudformation:GetTemplate
+    Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/eks-workshop-*/*

--- a/website/docs/troubleshooting/alb/alb_fix_5.md
+++ b/website/docs/troubleshooting/alb/alb_fix_5.md
@@ -55,6 +55,14 @@ $ aws iam detach-role-policy \
     --policy-arn ${LOAD_BALANCER_CONTROLLER_POLICY_ARN_ISSUE}
 ```
 
+#### 3.3. Restart the Load Balancer Controller to pick up the new subnet configuration
+
+```bash
+$ kubectl -n kube-system rollout restart deploy aws-load-balancer-controller
+deployment.apps/aws-load-balancer-controller restarted
+$ kubectl -n kube-system wait --for=condition=available deployment/aws-load-balancer-controller
+```
+
 ### Step 4: Verify the Fix
 
 Check if the ingress is now properly configured with an ALB:

--- a/website/docs/troubleshooting/alb/alb_fix_5.md
+++ b/website/docs/troubleshooting/alb/alb_fix_5.md
@@ -23,7 +23,7 @@ Example output:
 
 Let's examine the Load Balancer Controller logs to understand the permission issues:
 
-```bash wait=25
+```bash wait=25  expectError=true
 $ kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
 ```
 

--- a/website/docs/troubleshooting/alb/alb_fix_5.md
+++ b/website/docs/troubleshooting/alb/alb_fix_5.md
@@ -23,7 +23,7 @@ Example output:
 
 Let's examine the Load Balancer Controller logs to understand the permission issues:
 
-```bash wait=15
+```bash wait=25
 $ kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Some times during the scenario the controller takes to much time to auto-reload and it is faster if we reload the alb controller.

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
