### PR TITLE
update: updating to templatefile function instead of template provider for troubleshooting module

### DIFF
--- a/manifests/modules/troubleshooting/pod/.workshop/terraform/deployment_image.yaml
+++ b/manifests/modules/troubleshooting/pod/.workshop/terraform/deployment_image.yaml
@@ -34,7 +34,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
-          image: "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0"
+          image: "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/manifests/modules/troubleshooting/pod/.workshop/terraform/main.tf
+++ b/manifests/modules/troubleshooting/pod/.workshop/terraform/main.tf
@@ -67,19 +67,26 @@ resource "aws_iam_instance_profile" "ecr_ec2" {
   role = resource.aws_iam_role.ecr_ec2_role.name
 }
 
+resource "aws_ecr_repository" "ui" {
+  name                 = "retail-sample-app-ui"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+}
+
 resource "aws_instance" "ui_to_ecr" {
   ami                  = data.aws_ssm_parameter.eks_ami.value
   instance_type        = "m5.large"
   user_data            = <<-EOF
               #!/bin/bash
-              sudo yum update -y
-              sudo yum install -y docker
-              sudo service docker start
-              sudo usermod -a -G docker ec2-user
-              docker pull public.ecr.aws/aws-containers/retail-store-sample-ui:1.0.0
-              docker images | grep retail-store | awk '{ print $3 }' | xargs -I {} docker tag {} ${resource.aws_ecr_repository.ui.repository_url}:1.0.0
-              aws ecr get-login-password | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com
-              docker push ${resource.aws_ecr_repository.ui.repository_url}:1.0.0
+              sudo dnf update -y
+              curl -L https://github.com/containerd/nerdctl/releases/download/v1.7.7/nerdctl-1.7.7-linux-amd64.tar.gz | sudo tar -xz -C /usr/local/bin
+              sudo systemctl start containerd
+              sudo systemctl enable containerd
+              sudo /usr/local/bin/nerdctl pull public.ecr.aws/aws-containers/retail-store-sample-ui:1.2.1
+              sudo /usr/local/bin/nerdctl images | grep retail-store | awk '{ print $3 }' | xargs -I {} sudo /usr/local/bin/nerdctl tag {} ${resource.aws_ecr_repository.ui.repository_url}:1.2.1
+              aws ecr get-login-password | sudo /usr/local/bin/nerdctl login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com
+              sudo /usr/local/bin/nerdctl push ${resource.aws_ecr_repository.ui.repository_url}:1.2.1
               EOF
   subnet_id            = element(data.aws_subnets.selected.ids, 0)
   iam_instance_profile = resource.aws_iam_instance_profile.ecr_ec2.name
@@ -89,12 +96,6 @@ resource "aws_instance" "ui_to_ecr" {
   depends_on = [resource.aws_ecr_repository.ui]
 }
 
-resource "aws_ecr_repository" "ui" {
-  name                 = "retail-sample-app-ui"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = true
-
-}
 
 data "aws_iam_policy_document" "private_registry" {
   statement {
@@ -132,31 +133,19 @@ resource "aws_ecr_repository_policy" "example" {
   depends_on = [resource.aws_instance.ui_to_ecr]
 }
 
-data "template_file" "deployment_yaml1" {
-  template = file("${path.module}/deployment_permissions.yaml.tpl")
-
-  vars = {
-    image = "${resource.aws_ecr_repository.ui.repository_url}:1.0.0"
-  }
-}
-
-
-resource "local_file" "deployment_yaml1" {
-  filename = "${path.module}/deployment_permissions.yaml"
-  content  = data.template_file.deployment_yaml1.rendered
-}
-
 resource "null_resource" "kustomize_app1" {
   triggers = {
     always_run = timestamp()
   }
 
   provisioner "local-exec" {
-    command = "kubectl apply -f ${path.module}/deployment_permissions.yaml"
-    when    = create
+    command = "kubectl apply -f - <<EOF\n${templatefile("${path.module}/deployment_permissions.yaml.tpl", {
+      image = "${resource.aws_ecr_repository.ui.repository_url}:1.2.1"
+    })}\nEOF"
+    when = create
   }
 
-  depends_on = [resource.local_file.deployment_yaml1, resource.aws_instance.ui_to_ecr]
+  depends_on = [resource.aws_instance.ui_to_ecr]
 }
 
 
@@ -228,28 +217,17 @@ resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
   ip_protocol       = "-1" # semantically equivalent to all ports
 }
 
-data "template_file" "deployment_yaml2" {
-  template = file("${path.module}/deployment_crash.yaml.tpl")
-
-  vars = {
-    filesystemid = resource.aws_efs_file_system.efs.id
-  }
-}
-
-resource "local_file" "deployment_yaml2" {
-  filename = "${path.module}/deployment_crash.yaml"
-  content  = data.template_file.deployment_yaml2.rendered
-}
-
 resource "null_resource" "kustomize_app3" {
   triggers = {
     always_run = timestamp()
   }
 
   provisioner "local-exec" {
-    command = "kubectl apply -f ${path.module}/deployment_crash.yaml"
-    when    = create
+    command = "kubectl apply -f - <<EOF\n${templatefile("${path.module}/deployment_crash.yaml.tpl", {
+      filesystemid = resource.aws_efs_file_system.efs.id
+    })}\nEOF"
+    when = create
   }
 
-  depends_on = [resource.local_file.deployment_yaml2, resource.aws_efs_file_system.efs]
+  depends_on = [resource.aws_efs_file_system.efs]
 }

--- a/website/docs/troubleshooting/pod/private_image.md
+++ b/website/docs/troubleshooting/pod/private_image.md
@@ -40,18 +40,18 @@ Events:
   Type     Reason     Age                    From               Message
   ----     ------     ----                   ----               -------
   Normal   Scheduled  5m15s                  default-scheduler  Successfully assigned default/ui-private-7655bf59b9-jprrj to ip-10-42-33-232.us-west-2.compute.internal
-  Normal   Pulling    3m53s (x4 over 5m15s)  kubelet            Pulling image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0"
-  Warning  Failed     3m53s (x4 over 5m14s)  kubelet            Failed to pull image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0": failed to pull and unpack image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0": failed to resolve reference "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0": unexpected status from HEAD request to https:/"1234567890.dkr.ecr.us-west-2.amazonaws.com/v2/retail-sample-app-ui/manifests/1.0.0: 403 Forbidden
+  Normal   Pulling    3m53s (x4 over 5m15s)  kubelet            Pulling image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1"
+  Warning  Failed     3m53s (x4 over 5m14s)  kubelet            Failed to pull image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1": failed to pull and unpack image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1": failed to resolve reference "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1": unexpected status from HEAD request to https:/"1234567890.dkr.ecr.us-west-2.amazonaws.com/v2/retail-sample-app-ui/manifests/1.2.1: 403 Forbidden
   Warning  Failed     3m53s (x4 over 5m14s)  kubelet            Error: ErrImagePull
   Warning  Failed     3m27s (x6 over 5m14s)  kubelet            Error: ImagePullBackOff
-  Normal   BackOff    4s (x21 over 5m14s)    kubelet            Back-off pulling image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0"
+  Normal   BackOff    4s (x21 over 5m14s)    kubelet            Back-off pulling image "1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1"
 ```
 
 From the events of the pod, we can see the 'Failed to pull image' warning, with cause as 403 Forbidden. This indicates that the kubelet faced access denied while trying to pull the image used in the deployment. Let's get the URI of the image used in the deployment.
 
 ```bash
 $ kubectl get deploy ui-private -o jsonpath='{.spec.template.spec.containers[*].image}'
-"1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0"
+"1234567890.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1"
 ```
 
 ### Step 3: Check the image reference
@@ -59,7 +59,7 @@ $ kubectl get deploy ui-private -o jsonpath='{.spec.template.spec.containers[*].
 From the image URI, the image is referenced from the account where our EKS cluster is in. Let's check the ECR repository to see if any such image exists.
 
 ```bash
-$ aws ecr describe-images --repository-name retail-sample-app-ui --image-ids imageTag=1.0.0
+$ aws ecr describe-images --repository-name retail-sample-app-ui --image-ids imageTag=1.2.1
 {
     "imageDetails": [
         {
@@ -67,7 +67,7 @@ $ aws ecr describe-images --repository-name retail-sample-app-ui --image-ids ima
             "repositoryName": "retail-sample-app-ui",
             "imageDigest": "sha256:b338785abbf5a5d7e0f6ebeb8b8fc66e2ef08c05b2b48e5dfe89d03710eec2c1",
             "imageTags": [
-                "1.0.0"
+                "1.2.1"
             ],
             "imageSizeInBytes": 268443135,
             "imagePushedAt": "2024-10-11T14:03:01.207000+00:00",
@@ -78,10 +78,10 @@ $ aws ecr describe-images --repository-name retail-sample-app-ui --image-ids ima
 }
 ```
 
-The image path we have in deployment i.e. account_id.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.0.0 have a valid registryId i.e. account-number, valid repositoryName i.e. "retail-sample-app-ui" and valid imageTag i.e. "1.0.0". Which confirms the path of the image is correct and is not a wrong reference.
+The image path we have in deployment i.e. account_id.dkr.ecr.us-west-2.amazonaws.com/retail-sample-app-ui:1.2.1 have a valid registryId i.e. account-number, valid repositoryName i.e. "retail-sample-app-ui" and valid imageTag i.e. "1.2.1". Which confirms the path of the image is correct and is not a wrong reference.
 
 :::info
-Alternatively, you can also check from the ECR console. Click the button below to open the ECR Console. Then click on retail-sample-app-ui repository and the image tag 1.0.0.
+Alternatively, you can also check from the ECR console. Click the button below to open the ECR Console. Then click on retail-sample-app-ui repository and the image tag 1.2.1.
 <ConsoleButton
   url="https://us-west-2.console.aws.amazon.com/ecr/private-registry/repositories?region=us-west-2"
   service="ecr"

--- a/website/docs/troubleshooting/pod/public_image.md
+++ b/website/docs/troubleshooting/pod/public_image.md
@@ -40,10 +40,10 @@ Events:
   Type     Reason     Age                From               Message
   ----     ------     ----               ----               -------
   Normal   Scheduled  48s                default-scheduler  Successfully assigned default/ui-new-5654dd8969-7w98k to ip-10-42-33-232.us-west-2.compute.internal
-  Normal   BackOff    23s (x2 over 47s)  kubelet            Back-off pulling image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0"
+  Normal   BackOff    23s (x2 over 47s)  kubelet            Back-off pulling image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1"
   Warning  Failed     23s (x2 over 47s)  kubelet            Error: ImagePullBackOff
-  Normal   Pulling    12s (x3 over 47s)  kubelet            Pulling image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0"
-  Warning  Failed     12s (x3 over 47s)  kubelet            Failed to pull image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0": rpc error: code = NotFound desc = failed to pull and unpack image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0": failed to resolve reference "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0": public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0: not found
+  Normal   Pulling    12s (x3 over 47s)  kubelet            Pulling image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1"
+  Warning  Failed     12s (x3 over 47s)  kubelet            Failed to pull image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1": rpc error: code = NotFound desc = failed to pull and unpack image "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1": failed to resolve reference "public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1": public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1: not found
   Warning  Failed     12s (x3 over 47s)  kubelet            Error: ErrImagePull
 ```
 
@@ -55,31 +55,31 @@ Let's check the image used by the pod.
 
 ```bash
 $ kubectl get pod $POD -o jsonpath='{.spec.containers[*].image}'
-public.ecr.aws/aws-containers/retailing-store-sample-ui:1.0.0
+public.ecr.aws/aws-containers/retailing-store-sample-ui:1.2.1
 ```
 
 From the image URI, we can see that the image is referenced from public ECR repository of AWS.
 
 ### Step 4: Verify image existence
 
-Let's check if image named retailing-store-sample-ui with tag 1.0.0 exists at [aws-containers ECR](https://gallery.ecr.aws/aws-containers). Search for the "retailing-store-sample-ui" and you will notice that no such image repository shows up. You can also easily verify the image existence in public ECR by using the image URI in a browser. In our case [image-uri](https://gallery.ecr.aws/aws-containers/retailing-store-sample-ui) will show a "Repository not found" message.
+Let's check if image named retailing-store-sample-ui with tag 1.2.1 exists at [aws-containers ECR](https://gallery.ecr.aws/aws-containers). Search for the "retailing-store-sample-ui" and you will notice that no such image repository shows up. You can also easily verify the image existence in public ECR by using the image URI in a browser. In our case [image-uri](https://gallery.ecr.aws/aws-containers/retailing-store-sample-ui) will show a "Repository not found" message.
 
 ![RepoDoesNotExist](assets/rep-not-found.webp)
 
 ### Step 5: Update the deployment with the correct image
 
-To resolve the issue, we will have to update the deployment/pod spec with correct image reference. In our case it is public.ecr.aws/aws-containers/retail-store-sample-ui:1.0.0.
+To resolve the issue, we will have to update the deployment/pod spec with correct image reference. In our case it is public.ecr.aws/aws-containers/retail-store-sample-ui:1.2.1.
 
 #### 5.1. Verify if image exists
 
-Before we update the deployment, let's verify if this image exists using above mentioned method i.e. by visiting the [image-uri](https://gallery.ecr.aws/aws-containers/retail-store-sample-ui). You should be able to see the retail-store-sample-ui image with multiple tags available, including 1.0.0.
+Before we update the deployment, let's verify if this image exists using above mentioned method i.e. by visiting the [image-uri](https://gallery.ecr.aws/aws-containers/retail-store-sample-ui). You should be able to see the retail-store-sample-ui image with multiple tags available, including 1.2.1.
 
 ![RepoExist](assets/repo-found.webp)
 
 #### 5.1. Update image in the deployment with correct reference
 
 ```bash
-$ kubectl patch deployment ui-new --patch '{"spec": {"template": {"spec": {"containers": [{"name": "ui", "image": "public.ecr.aws/aws-containers/retail-store-sample-ui:1.0.0"}]}}}}'
+$ kubectl patch deployment ui-new --patch '{"spec": {"template": {"spec": {"containers": [{"name": "ui", "image": "public.ecr.aws/aws-containers/retail-store-sample-ui:1.2.1"}]}}}}'
 deployment.apps/ui-new patched
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Migrate from using the template provider to the templatefile function as noted in the provider docs. That provider is deprecated https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file. 

Also updated the ecr image generation for one scenario to use containerd to push the image to ECR instead of docker.

#### Quality checks

- [x ] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
