### PR TITLE
fix: permissions issues when running prep-env for storage

### DIFF
--- a/lab/iam/policies/iam.yaml
+++ b/lab/iam/policies/iam.yaml
@@ -83,3 +83,4 @@ Statement:
           - spot.amazonaws.com
           - fis.amazonaws.com
           - transitgateway.amazonaws.com
+          - fsx.amazonaws.com


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixed permission issues when running prepare-environment fundamentals/storage/fsxn 

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
