### PR TITLE
fix: Fixing timeout for prepenv for troubleshooting module DNS scenario

### DIFF
--- a/website/docs/troubleshooting/dns/index.md
+++ b/website/docs/troubleshooting/dns/index.md
@@ -13,13 +13,12 @@ In this lab, we will investigate a scenario where service communication is disru
 :::tip Before you start
 Prepare your environment for this section:
 
-```bash timeout=600 wait=5
+```bash timeout=900 wait=10
 $ prepare-environment troubleshooting/dns
 ```
+
 The prepare-environment script for this module resets the workshop environment.
 :::
-
-
 
 ### DNS resolution in EKS
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixed timeout that occurred when executing `prepare-environment troubleshooting/dns` for the very first time

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
