### PR TITLE
chore(deps): Replace hey by oha

### DIFF
--- a/website/docs/fundamentals/workloads/horizontal-pod-autoscaler/test-hpa.md
+++ b/website/docs/fundamentals/workloads/horizontal-pod-autoscaler/test-hpa.md
@@ -3,7 +3,7 @@ title: "Generate load"
 sidebar_position: 20
 ---
 
-To observe HPA scale out in response to the policy we have configured we need to generate some load on our application. We'll do that by calling the home page of the workload with [hey](https://github.com/rakyll/hey).
+To observe HPA scale out in response to the policy we have configured we need to generate some load on our application. We'll do that by calling the home page of the workload with [oha](https://github.com/hatoo/oha).
 
 The command below will run the load generator with:
 
@@ -13,8 +13,8 @@ The command below will run the load generator with:
 
 ```bash hook=hpa-pod-scaleout hookTimeout=330
 $ kubectl run load-generator \
-  --image=williamyeh/hey:latest \
-  --restart=Never -- -c 10 -q 5 -z 60m http://ui.ui.svc/home
+  --image=ghcr.io/hatoo/oha:latest \
+  --restart=Never -- -c 10 -q 5 -z 60m --no-tui http://ui.ui.svc/home
 ```
 
 Now that we have requests hitting our application we can watch the HPA resource to follow its progress:

--- a/website/docs/fundamentals/workloads/keda/test-keda.md
+++ b/website/docs/fundamentals/workloads/keda/test-keda.md
@@ -3,7 +3,7 @@ title: "Generate load"
 sidebar_position: 20
 ---
 
-To observe KEDA scale the deployment in response to the KEDA `ScaledObject` we have configured, we need to generate some load on our application. We'll do that by calling the home page of the workload with [hey](https://github.com/rakyll/hey).
+To observe KEDA scale the deployment in response to the KEDA `ScaledObject` we have configured, we need to generate some load on our application. We'll do that by calling the home page of the workload with [oha](https://github.com/hatoo/oha).
 
 The command below will run the load generator with:
 
@@ -14,8 +14,8 @@ The command below will run the load generator with:
 ```bash hook=keda-pod-scaleout hookTimeout=330
 $ export ALB_HOSTNAME=$(kubectl get ingress ui -n ui -o yaml | yq .status.loadBalancer.ingress[0].hostname)
 $ kubectl run load-generator \
-  --image=williamyeh/hey:latest \
-  --restart=Never -- -c 3 -q 5 -z 10m http://$ALB_HOSTNAME/home
+  --image=ghcr.io/hatoo/oha:latest \
+  --restart=Never -- -c 3 -q 5 -z 10m --no-tui http://$ALB_HOSTNAME/home
 ```
 
 Based on the `ScaledObject`, KEDA creates an HPA resource and provides the required metrics to allow the HPA to scale the workload. Now that we have requests hitting our application we can watch the HPA resource to follow its progress:


### PR DESCRIPTION
#### What this PR does / why we need it:

Hey is unmaintained since 2021
See this issue for discussions/alternative: https://github.com/rakyll/hey/issues/314

#### Which issue(s) this PR fixes:

I propose to use [oha](https://github.com/hatoo/oha) as a drop-in replacement (same options)

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
