### PR TITLE
fix: eks-mcp.json to fix EKS MCP server loading

### DIFF
--- a/manifests/modules/aiml/q-cli/setup/eks-mcp.json
+++ b/manifests/modules/aiml/q-cli/setup/eks-mcp.json
@@ -3,6 +3,8 @@
     "awslabs.eks-mcp-server": {
       "command": "uvx",
       "args": [
+        "--with",      
+        "mcp==1.18.0",
         "awslabs.eks-mcp-server@0.1.13",
         "--allow-write",
         "--allow-sensitive-data-access"


### PR DESCRIPTION
The lab is currently breaking as the EKS MCP server is not loading properly because of MCP version issue. The suggested change is tested and worked fine for the entire module. This is a temporary fix for the module until the new changes for "kiro-cli" are fully done.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>
Q CLI
-->

#### What this PR does / why we need it:
This PR adds the version of MCP in the `mcp.json` file.
#### Which issue(s) this PR fixes:
Q CLI lab not able to start EKS MCP server
Fixes #

#### Quality checks

- [X] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
