### PR TITLE
fix: Add missing coredns and kube-proxy EKS addons

### DIFF
--- a/cluster/terraform/eks.tf
+++ b/cluster/terraform/eks.tf
@@ -28,6 +28,12 @@ module "eks" {
         enableNetworkPolicy = "true"
       })
     }
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
   }
 
   vpc_id     = module.vpc.vpc_id


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the missing `coredns` and `kube-proxy` EKS managed addons to the Terraform cluster configuration.

The `terraform-aws-modules/eks/aws` module version 21.x has `bootstrap_self_managed_addons = false` by default (see [UPGRADE-21.0 docs](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-21.0.md)), which means all addons must be explicitly declared via the EKS addons API.

Without these addons:
- `coredns` - No DNS resolution, causing pods to fail with errors like `java.net.UnknownHostException: carts-dynamodb`
- `kube-proxy` - Required for Kubernetes networking and service discovery

#### Which issue(s) this PR fixes:

Fixes #1782

#### Changes Made:

Added to `cluster/terraform/eks.tf`:
```hcl
coredns = {
  most_recent = true
}
kube-proxy = {
  most_recent = true
}
```

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

Note: This is a Terraform configuration change that requires an actual EKS cluster to test. The change follows the pattern established in the existing `vpc-cni` addon configuration and aligns with the module documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.