### PR TITLE
docs: Add ExternalSecret manifest for clarity

### DIFF
--- a/website/docs/security/secrets-management/secrets-manager/external-secrets.md
+++ b/website/docs/security/secrets-management/secrets-manager/external-secrets.md
@@ -39,13 +39,15 @@ $ cat ~/environment/eks-workshop/modules/security/secrets-manager/cluster-secret
   | envsubst | kubectl apply -f -
 ```
 
-Next, we'll create an `ExternalSecret` that defines what data should be fetched from AWS Secrets Manager and how it should be transformed into a Kubernetes Secret. We'll then update our `catalog` Deployment to use these credentials.
+Next, we'll create an `ExternalSecret` that defines what data should be fetched from AWS Secrets Manager and how it should be transformed into a Kubernetes Secret.
 
 Let's inspect the `ExternalSecret` manifest that will be applied:
 
 ::yaml{file="manifests/modules/security/secrets-manager/external-secrets/external-secret.yaml"}
 
 This tells the External Secrets Operator to pull the secret identified by `$SECRET_NAME` from the `ClusterSecretStore` and sync it into the `catalog` namespace every hour.
+
+We'll also update our `catalog` Deployment to use these credentials:
 
 ```kustomization
 modules/security/secrets-manager/external-secrets/kustomization.yaml

--- a/website/docs/security/secrets-management/secrets-manager/external-secrets.md
+++ b/website/docs/security/secrets-management/secrets-manager/external-secrets.md
@@ -39,7 +39,13 @@ $ cat ~/environment/eks-workshop/modules/security/secrets-manager/cluster-secret
   | envsubst | kubectl apply -f -
 ```
 
-Next, we'll create an `ExternalSecret` that defines what data should be fetched from AWS Secrets Manager and how it should be transformed into a Kubernetes Secret. We'll then update our `catalog` Deployment to use these credentials:
+Next, we'll create an `ExternalSecret` that defines what data should be fetched from AWS Secrets Manager and how it should be transformed into a Kubernetes Secret. We'll then update our `catalog` Deployment to use these credentials.
+
+Let's inspect the `ExternalSecret` manifest that will be applied:
+
+::yaml{file="manifests/modules/security/secrets-manager/external-secrets/external-secret.yaml"}
+
+This tells the External Secrets Operator to pull the secret identified by `$SECRET_NAME` from the `ClusterSecretStore` and sync it into the `catalog` namespace every hour.
 
 ```kustomization
 modules/security/secrets-manager/external-secrets/kustomization.yaml


### PR DESCRIPTION
Fixes #1442 — adds the external-secret.yaml content inline so users can understand how the secret is pulled from AWS Secrets Manager without having to dig into the repo.