### PR TITLE
docs: Clarify that EKS access policy table is not exhaustive

### DIFF
--- a/website/docs/security/cluster-access-management/understanding.md
+++ b/website/docs/security/cluster-access-management/understanding.md
@@ -23,6 +23,7 @@ The Cluster Access Management API relies on two basic concepts:
 | AmazonEKSEditPolicy         | `edit`          | Grants access to edit most Kubernetes resources, usually scoped to a Namespace                               |
 | AmazonEKSViewPolicy         | `view`          | Grants access to list/view most Kubernetes resources, usually scoped to a Namespace                          |
 | AmazonEMRJobPolicy          | N/A             | Custom access to run Amazon EMR Jobs on Amazon EKS Clusters                                                  |
+
 The table above shows a subset of commonly used access policies. AWS adds new policies over time (for example, for EKS Auto Mode, ArgoCD, KRO, SageMaker HyperPod, and others). To see the complete and up-to-date list of policies available in your account, run:
 
 ```bash

--- a/website/docs/security/cluster-access-management/understanding.md
+++ b/website/docs/security/cluster-access-management/understanding.md
@@ -23,8 +23,7 @@ The Cluster Access Management API relies on two basic concepts:
 | AmazonEKSEditPolicy         | `edit`          | Grants access to edit most Kubernetes resources, usually scoped to a Namespace                               |
 | AmazonEKSViewPolicy         | `view`          | Grants access to list/view most Kubernetes resources, usually scoped to a Namespace                          |
 | AmazonEMRJobPolicy          | N/A             | Custom access to run Amazon EMR Jobs on Amazon EKS Clusters                                                  |
-
-To check the list of available access policies in your account, run the following command:
+The table above shows a subset of commonly used access policies. AWS adds new policies over time (for example, for EKS Auto Mode, ArgoCD, KRO, SageMaker HyperPod, and others). To see the complete and up-to-date list of policies available in your account, run:
 
 ```bash
 $ aws eks list-access-policies


### PR DESCRIPTION
Fixes #1596 — the table of EKS access policies only shows a subset. Added a note directing users to run aws eks list-access-policies for the full current list, since AWS continues to add new policies.