### PR TITLE
update: PEEKS workshop integration in Automation

### DIFF
--- a/website/docs/automation/platform-engineering-on-eks/index.md
+++ b/website/docs/automation/platform-engineering-on-eks/index.md
@@ -1,0 +1,12 @@
+---
+title: "Platform Engineering on EKS"
+sidebar_custom_props: { "explore": "https://catalog.workshops.aws/platform-engineering-on-eks/en-US" }
+sidebar_position: 90
+---
+
+Development teams often struggle with inconsistent tooling and complex provisioning processes. The Cloud Native Computing Foundation (CNCF) defines a platform as "an integrated collection of capabilities defined and presented according to the needs of the platform's users" — in short, a unified layer that brings together the services and tools applications need, with a simple experience through web portals, templates, and APIs.
+
+Platform Engineering on EKS is a hands-on workshop that shows you how to build an internal developer platform (IDP) with developer self-service at its core. You'll set up a unified developer portal with Backstage, use ACK and KRO for standardized infrastructure-as-code provisioning of AWS resources, and explore practical patterns for namespace-as-a-service workflows, policy-as-code, and GitOps — all on Amazon EKS.
+
+
+<LaunchButton url="https://catalog.workshops.aws/platform-engineering-on-eks/en-US" label="Platform Engineering on EKS" />


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds direct link to Platform Engineering on EKS workshop in order to provide our customers of EKS Workshop with more tools to understand and learn about GitOps on Amazon EKS

#### Which issue(s) this PR fixes:
N/A — this is a content quality improvement with no associated issue.

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md) -> NOT APPLICABLE (this is just a single page of cumentation, no code involved)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
