### PR TITLE
chore(lab): migrate IDE tool installation to mise

### DIFF
--- a/lab/Dockerfile
+++ b/lab/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN yum install -y tar gzip vi shadow-utils sudo && useradd \
+RUN yum install -y --allowerasing tar gzip vi shadow-utils sudo curl && useradd \
     --home "/home/ec2-user" \
     --create-home \
     --user-group \
@@ -8,6 +8,31 @@ RUN yum install -y tar gzip vi shadow-utils sudo && useradd \
     ec2-user
 
 RUN echo "ec2-user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Install mise to a system-wide location accessible to all users
+# renovate: depName=jdx/mise
+ARG MISE_VERSION="2026.4.18"
+RUN curl -fsSL "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/install.sh" | \
+    MISE_INSTALL_PATH=/usr/local/bin/mise sh
+ENV PATH="/usr/local/bin:$PATH"
+
+# Configure mise for system-wide tool installation
+ENV MISE_DATA_DIR="/usr/local/share/mise"
+ENV MISE_CACHE_DIR="/usr/local/share/mise/cache"
+
+# Make mise shims available to all users at runtime
+ENV PATH="/usr/local/share/mise/shims:$PATH"
+
+COPY mise.toml /tmp/mise.toml
+RUN mise trust /tmp/mise.toml && \
+    mise install --cd /tmp && \
+    # Place global tool config in ec2-user home — runtime user in this container
+    mkdir -p /home/ec2-user/.config/mise && \
+    cp /tmp/mise.toml /home/ec2-user/.config/mise/config.toml && \
+    chown -R ec2-user:ec2-user /home/ec2-user/.config && \
+    chmod -R 755 /usr/local/share/mise && \
+    # Allow ec2-user to write mise cache at runtime
+    chown -R ec2-user:ec2-user /usr/local/share/mise/cache
 
 ADD scripts/installer.sh /tmp/installer.sh
 

--- a/lab/mise.toml
+++ b/lab/mise.toml
@@ -1,0 +1,17 @@
+[tools]
+# Tools with registered short names — full Renovate support via mise manager
+kubectl   = "1.33.7"
+helm      = "3.20.0"
+eksctl    = "0.222.0"
+yq        = "4.52.2"
+flux2     = "2.7.5"
+argocd    = "2.14.21"
+terraform = "1.14.4"
+
+# Tools via github: backend — require extractVersion overrides in renovate.json
+# because their release tags use a v-prefix that is not stripped automatically.
+# kubeseal and ec2-instance-selector have no Renovate tracking in the previous
+# installer.sh; this is the first time they will receive automated updates.
+"github:hatoo/oha"                          = "1.13.0"
+"github:bitnami-labs/sealed-secrets"        = "0.18.4"
+"github:aws/amazon-ec2-instance-selector"   = "3.1.1"

--- a/lab/scripts/installer.sh
+++ b/lab/scripts/installer.sh
@@ -2,70 +2,7 @@
 
 set -e
 
-# renovate: depName=kubernetes/kubernetes
-kubectl_version='1.33.7'
-
-# renovate: depName=helm/helm
-helm_version='3.20.0'
-
-# renovate: depName=eksctl-io/eksctl
-eksctl_version='0.222.0'
-
-kubeseal_version='0.18.4'
-
-# renovate: depName=mikefarah/yq
-yq_version='4.52.2'
-
-# renovate: depName=fluxcd/flux2
-flux_version='2.7.5'
-
-# renovate: depName=argoproj/argo-cd
-argocd_version='2.14.21'
-
-# renovate: depName=hashicorp/terraform
-terraform_version='1.14.4'
-
-ec2_instance_selector_version='3.1.1'
-
-# renovate: depName=hatoo/oha
-oha_version='1.13.0'
-
-download () {
-  url=$1
-  out_file=$2
-
-  curl --location --show-error --silent --output $out_file $url
-}
-
-download_and_verify () {
-  url=$1
-  checksum=$2
-  out_file=$3
-
-  curl --location --show-error --silent --output $out_file $url
-
-  echo "$checksum $out_file" > "$out_file.sha256"
-  sha256sum --check "$out_file.sha256"
-
-  rm "$out_file.sha256"
-}
-
 arch=$(uname -m)
-arch_name=""
-
-# Convert to amd64 or arm64
-case "$arch" in
-  x86_64)
-    arch_name="amd64"
-    ;;
-  aarch64)
-    arch_name="arm64"
-    ;;
-  *)
-    echo "Unsupported architecture: $arch"
-    exit 1
-    ;;
-esac
 
 yum install --quiet -y findutils jq tar gzip zsh git diffutils wget \
   tree unzip openssl gettext bash-completion python3 python3-pip \
@@ -73,74 +10,14 @@ yum install --quiet -y findutils jq tar gzip zsh git diffutils wget \
 
 pip3 install -q awscurl==0.28 urllib3==1.26.6
 
-# kubectl
-download "https://dl.k8s.io/release/v$kubectl_version/bin/linux/${arch_name}/kubectl" "kubectl"
-chmod +x ./kubectl
-mv ./kubectl /usr/local/bin
-
-# helm
-download "https://get.helm.sh/helm-v$helm_version-linux-${arch_name}.tar.gz" "helm.tar.gz"
-tar zxf helm.tar.gz
-chmod +x linux-${arch_name}/helm
-mv ./linux-${arch_name}/helm /usr/local/bin
-rm -rf linux-${arch_name}/ helm.tar.gz
-
-# eksctl
-download "https://github.com/eksctl-io/eksctl/releases/download/v${eksctl_version}/eksctl_Linux_${arch_name}.tar.gz" "eksctl.tar.gz"
-tar zxf eksctl.tar.gz
-chmod +x eksctl
-mv ./eksctl /usr/local/bin
-rm -rf eksctl.tar.gz
-
 # aws cli v2
 curl --location --show-error --silent "https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip" -o "awscliv2.zip"
 unzip -o -q awscliv2.zip -d /tmp
 /tmp/aws/install --update
 rm -rf /tmp/aws awscliv2.zip
 
-# kubeseal
-download "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${kubeseal_version}/kubeseal-${kubeseal_version}-linux-${arch_name}.tar.gz" "kubeseal.tar.gz"
-tar xfz kubeseal.tar.gz
-chmod +x kubeseal
-mv ./kubeseal /usr/local/bin
-rm -rf kubeseal.tar.gz
-
-# yq
-download "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_${arch_name}" "yq"
-chmod +x ./yq
-mv ./yq /usr/local/bin
-
-# flux
-download "https://github.com/fluxcd/flux2/releases/download/v${flux_version}/flux_${flux_version}_linux_${arch_name}.tar.gz" "flux.tar.gz"
-tar zxf flux.tar.gz
-chmod +x flux
-mv ./flux /usr/local/bin
-rm -rf flux.tar.gz
-
-# git-remote
+# git-remote-s3
 pip install git-remote-s3
-
-# terraform
-download "https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_${arch_name}.zip" "terraform.zip"
-unzip -o -q terraform.zip -d /tmp
-chmod +x /tmp/terraform
-mv /tmp/terraform /usr/local/bin
-rm -f terraform.zip
-
-# argocd
-download "https://github.com/argoproj/argo-cd/releases/download/v${argocd_version}/argocd-linux-${arch_name}" "argocd"
-chmod +x ./argocd
-mv ./argocd /usr/local/bin/argocd
-
-# ec2 instance selector
-download "https://github.com/aws/amazon-ec2-instance-selector/releases/download/v${ec2_instance_selector_version}/ec2-instance-selector-linux-${arch_name}" "ec2-instance-selector"
-chmod +x ./ec2-instance-selector
-mv ./ec2-instance-selector /usr/local/bin/ec2-instance-selector
-
-# oha
-download "https://github.com/hatoo/oha/releases/download/v${oha_version}/oha-linux-${arch_name}" "oha"
-chmod +x ./oha
-mv ./oha /usr/local/bin
 
 REPOSITORY_OWNER=${REPOSITORY_OWNER:-"aws-samples"}
 REPOSITORY_NAME=${REPOSITORY_NAME:-"eks-workshop-v2"}

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":automergeStableNonMajor"
   ],
   "schedule": ["* * 7-14 * *"],
-  "enabledManagers": ["custom.regex", "github-actions", "terraform", "npm"],
+  "enabledManagers": ["custom.regex", "github-actions", "terraform", "npm", "mise"],
   "labels": ["content/other"],
   "minimumReleaseAge": "28 days",
   "internalChecksFilter": "strict",
@@ -37,28 +37,31 @@
       "automerge": true,
       "matchCurrentVersion": ">= 1.0.0",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchManagers": ["custom.regex"]
+      "matchManagers": ["custom.regex", "mise"]
     },
     {
       "matchPackagePatterns": ["^@docusaurus"],
       "enabled": false
     },
     {
-      "matchFileNames": ["lab/scripts/installer.sh"],
+      "matchFileNames": ["lab/mise.toml"],
       "groupName": "IDE binaries",
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchDepNames": ["github:hatoo/oha"],
+      "extractVersion": "^v(?<version>.+)$"
+    },
+    {
+      "matchDepNames": ["github:bitnami-labs/sealed-secrets"],
+      "extractVersion": "^v(?<version>.+)$"
+    },
+    {
+      "matchDepNames": ["github:aws/amazon-ec2-instance-selector"],
+      "extractVersion": "^v(?<version>.+)$"
     }
   ],
   "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["lab/scripts/installer.sh"],
-      "matchStrings": [
-        "depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version='(?<currentValue>.*)'\\s"
-      ],
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    },
     {
       "customType": "regex",
       "fileMatch": ["vars\\.tf$"],


### PR DESCRIPTION
Fixes #1805

## What this PR does

Replaces custom shell-based binary downloads in `installer.sh` with [mise](https://mise.jdx.dev/) for declarative tool version management. This removes the custom Renovate regex manager for `installer.sh` and replaces it with native mise manager support.

## Tools migrated to `lab/mise.toml`
- `kubectl`, `helm`, `eksctl`, `yq`, `flux2`, `argocd`, `terraform` (registered short names)
- `oha`, `kubeseal`, `ec2-instance-selector` (github: backend)

## Remaining in `installer.sh`
- AWS CLI v2 — no mise backend available
- `awscurl`, `git-remote-s3` — pip packages

## Renovate changes
- Added `mise` to `enabledManagers`
- Removed `installer.sh` custom regex manager
- Updated IDE binaries group to match `lab/mise.toml`
- Added `extractVersion` overrides for `github:` backend tools
- Extended automerge rule to cover mise manager

## Quality checks
- [x] My content adheres to the style guidelines
- [x] I ran `make test module="introduction"` it was successful
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

## Notes
- mise performs SLSA attestation verification for `github:` backend tools during `docker build`, which makes unauthenticated GitHub API calls. CI environments with `GITHUB_TOKEN` available will not hit rate limits.
- The `kubectl` version constraint in `renovate.json` (pinned to 1.33.x) is preserved.
- `--allowerasing` added to the initial `yum install` to resolve a `curl` vs `curl-minimal` package conflict on Amazon Linux 2023 base image.