### PR TITLE
update: kubectl get command to use endpointslices

### DIFF
--- a/website/docs/introduction/basics/services/index.md
+++ b/website/docs/introduction/basics/services/index.md
@@ -107,7 +107,7 @@ ui     ClusterIP   172.20.83.84    <none>        80/TCP    15m
 
 View service endpoints (the actual pod IPs):
 ```bash
-$ kubectl get endpoints -n ui ui
+$ kubectl get endpointslices -n ui
 NAME   ENDPOINTS           AGE
 ui     10.42.1.15:8080     15m
 ```
@@ -202,7 +202,7 @@ $ kubectl scale deployment -n ui ui --replicas=3
 
 **Watch how the service endpoints update:**
 ```bash
-$ kubectl get endpoints -n ui ui
+$ kubectl get endpointslices -n ui
 NAME   ENDPOINTS                                               AGE
 ui     10.42.117.212:8080,10.42.129.33:8080,10.42.174.4:8080   11m
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/introduction/basics/services/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/introduction/basics/services/index.md
@@ -108,7 +108,7 @@ ui     ClusterIP   172.20.83.84    <none>        80/TCP    15m
 
 Service のエンドポイント (実際の Pod IP) を表示します:
 ```bash
-$ kubectl get endpoints -n ui ui
+$ kubectl get endpointslices -n ui
 NAME   ENDPOINTS           AGE
 ui     10.42.1.15:8080     15m
 ```
@@ -203,7 +203,7 @@ $ kubectl scale deployment -n ui ui --replicas=3
 
 **Service のエンドポイントがどのように更新されるかを確認します:**
 ```bash
-$ kubectl get endpoints -n ui ui
+$ kubectl get endpointslices -n ui
 NAME   ENDPOINTS                                               AGE
 ui     10.42.117.212:8080,10.42.129.33:8080,10.42.174.4:8080   11m
 ```


### PR DESCRIPTION
spotted while at https://snapshots.eksworkshop.com/4f160659/docs/introduction/basics/services/#:~:text=Watch%20how%20the%20service%20endpoints%20update%3A





#### What this PR does / why we need it:

Use `kubectl get endpointslices -n ui`

to remove warning from

```
kubectl get endpoints -n ui ui
Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
```

#### Which issue(s) this PR fixes:

Fixes N/A

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
