### PR TITLE
feat(analytics): identify lab runs by per-env UUID instead of account ID

### DIFF
--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -111,7 +111,7 @@ if [ ! -z "$module" ]; then
   ANALYTICS_ENDPOINT=${ANALYTICS_ENDPOINT:-""}
 
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
-    curl --get -s --data-urlencode "lab=$module" --data-urlencode "env_id=$WORKSHOP_ENV_ID" --data-urlencode "resources_precreated=$RESOURCES_PRECREATED" $ANALYTICS_ENDPOINT || true
+    curl --get -s -o /dev/null --data-urlencode "ws=$WS" --data-urlencode "build=$BUILD" --data-urlencode "env=$WORKSHOP_ENV_ID" --data-urlencode "lab=$module" $ANALYTICS_ENDPOINT || true
   fi
 
   if [[ "$module" = "fastpaths/"* ]]; then

--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -111,7 +111,7 @@ if [ ! -z "$module" ]; then
   ANALYTICS_ENDPOINT=${ANALYTICS_ENDPOINT:-""}
 
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
-    curl --get -s --data-urlencode "lab=$module" --data-urlencode "env_id=$WORKSHOP_ENV_ID" $ANALYTICS_ENDPOINT || true
+    curl --get -s --data-urlencode "lab=$module" --data-urlencode "env_id=$WORKSHOP_ENV_ID" --data-urlencode "resources_precreated=$RESOURCES_PRECREATED" $ANALYTICS_ENDPOINT || true
   fi
 
   if [[ "$module" = "fastpaths/"* ]]; then

--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -111,8 +111,7 @@ if [ ! -z "$module" ]; then
   ANALYTICS_ENDPOINT=${ANALYTICS_ENDPOINT:-""}
 
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then
-    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
-    curl --get -s --data-urlencode "lab=$module" --data-urlencode "account_id=$AWS_ACCOUNT_ID" $ANALYTICS_ENDPOINT || true
+    curl --get -s --data-urlencode "lab=$module" --data-urlencode "env_id=$WORKSHOP_ENV_ID" $ANALYTICS_ENDPOINT || true
   fi
 
   if [[ "$module" = "fastpaths/"* ]]; then

--- a/lab/cfn/eks-workshop-vscode-cfn.yaml
+++ b/lab/cfn/eks-workshop-vscode-cfn.yaml
@@ -28,6 +28,18 @@ Parameters:
     Type: String
     Description: Analytics endpoint used for AWS events
     Default: ""
+  WS:
+    Type: String
+    Description: Workshop Studio workshop id (empty for self-paced)
+    Default: ""
+  BUILD:
+    Type: String
+    Description: Workshop content build/commit id (empty for self-paced)
+    Default: ""
+  ENV:
+    Type: String
+    Description: Workshop Studio team id (empty for self-paced)
+    Default: ""
   CodeServerVersion:
     Type: String
     Description: Default code-server version to use
@@ -313,6 +325,9 @@ Resources:
                   export REPOSITORY_REF="${RepositoryRef}"
                   export RESOURCES_PRECREATED="${ResourcesPrecreated}"
                   export ANALYTICS_ENDPOINT="${AnalyticsEndpoint}"
+                  export WS="${WS}"
+                  export BUILD="${BUILD}"
+                  export ENV="${ENV}"
                   IMDS_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
                   IDE_IP=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
                   export BASE_INBOUND_CIDRS="${InboundCIDR},$IDE_IP/32"

--- a/lab/cfn/eks-workshop-vscode-cfn.yaml
+++ b/lab/cfn/eks-workshop-vscode-cfn.yaml
@@ -27,7 +27,7 @@ Parameters:
   AnalyticsEndpoint:
     Type: String
     Description: Analytics endpoint used for AWS events
-    Default: "https://www.eksworkshop.com/analytics/track"
+    Default: ""
   CodeServerVersion:
     Type: String
     Description: Default code-server version to use

--- a/lab/cfn/eks-workshop-vscode-cfn.yaml
+++ b/lab/cfn/eks-workshop-vscode-cfn.yaml
@@ -27,7 +27,7 @@ Parameters:
   AnalyticsEndpoint:
     Type: String
     Description: Analytics endpoint used for AWS events
-    Default: ""
+    Default: "https://www.eksworkshop.com/analytics/track"
   CodeServerVersion:
     Type: String
     Description: Default code-server version to use

--- a/lab/scripts/setup.sh
+++ b/lab/scripts/setup.sh
@@ -78,15 +78,19 @@ RESOURCES_PRECREATED=${RESOURCES_PRECREATED:-"false"}
 
 echo "export RESOURCES_PRECREATED='${RESOURCES_PRECREATED}'" > ~/.bashrc.d/infra.bash
 
-# Analytics: stable per-environment UUID.
-# Generated once per environment.
+# Analytics: stable per-environment id.
+# Use the Workshop Studio team id (ENV) when present (AWS-hosted events);
+# otherwise generate + persist a random per-environment UUID.
 ENV_ID_FILE=~/.workshop-env-id
 if [ ! -s "$ENV_ID_FILE" ]; then
   cat /proc/sys/kernel/random/uuid > "$ENV_ID_FILE"
 fi
+WORKSHOP_ENV_ID="${ENV:-$(cat "$ENV_ID_FILE")}"
 
 echo "export ANALYTICS_ENDPOINT='${ANALYTICS_ENDPOINT}'" > ~/.bashrc.d/analytics.bash
-echo "export WORKSHOP_ENV_ID='$(cat "$ENV_ID_FILE")'" >> ~/.bashrc.d/analytics.bash
+echo "export WORKSHOP_ENV_ID='${WORKSHOP_ENV_ID}'" >> ~/.bashrc.d/analytics.bash
+echo "export WS='${WS}'" >> ~/.bashrc.d/analytics.bash
+echo "export BUILD='${BUILD}'" >> ~/.bashrc.d/analytics.bash
 
 echo "export BASE_INBOUND_CIDRS='${BASE_INBOUND_CIDRS}'" > ~/.bashrc.d/inbound-cidr.bash
 

--- a/lab/scripts/setup.sh
+++ b/lab/scripts/setup.sh
@@ -78,7 +78,15 @@ RESOURCES_PRECREATED=${RESOURCES_PRECREATED:-"false"}
 
 echo "export RESOURCES_PRECREATED='${RESOURCES_PRECREATED}'" > ~/.bashrc.d/infra.bash
 
+# Analytics: stable per-environment UUID.
+# Generated once per environment.
+ENV_ID_FILE=~/.workshop-env-id
+if [ ! -s "$ENV_ID_FILE" ]; then
+  cat /proc/sys/kernel/random/uuid > "$ENV_ID_FILE"
+fi
+
 echo "export ANALYTICS_ENDPOINT='${ANALYTICS_ENDPOINT}'" > ~/.bashrc.d/analytics.bash
+echo "export WORKSHOP_ENV_ID='$(cat "$ENV_ID_FILE")'" >> ~/.bashrc.d/analytics.bash
 
 echo "export BASE_INBOUND_CIDRS='${BASE_INBOUND_CIDRS}'" > ~/.bashrc.d/inbound-cidr.bash
 


### PR DESCRIPTION
## What

Reworks the currently optional lab-usage analytics ping so it identifies a run by a **random per-environment UUID**, and enables it by default.

- `lab/scripts/setup.sh` Ensure right params are passed into environment variables.
- `lab/bin/reset-environment` — send the right params to the analytics endpoints when it's defined.

## Why

- **No account data / no PII** - the identifier is a random UUID, never derived from the account.
- **Accurate unique-environment counts** — `COUNT(DISTINCT env_id)` counts real environments, not reused account IDs.

