### PR TITLE
feat: Convert kro lab to managed Amazon EKS Capabilities for kro and ACK

### DIFF
--- a/manifests/modules/automation/controlplanes/kro/.workshop/cleanup.sh
+++ b/manifests/modules/automation/controlplanes/kro/.workshop/cleanup.sh
@@ -13,5 +13,3 @@ delete-all-if-crd-exists resourcegraphdefinitions.kro.run
 kubectl delete crd/webapplicationdynamodbs.kro.run --ignore-not-found
 
 kubectl delete crd/webapplications.kro.run --ignore-not-found
-
-uninstall-helm-chart kro kro-system

--- a/manifests/modules/automation/controlplanes/kro/.workshop/terraform/main.tf
+++ b/manifests/modules/automation/controlplanes/kro/.workshop/terraform/main.tf
@@ -157,9 +157,11 @@ resource "aws_iam_role_policy" "ack_capability_iam" {
         # Role + inline/attached-policy actions the ACK iam-controller needs to
         # create, reconcile, and delete the Role its RGD defines. Mirrors the
         # role/policy subset of the ACK iam-controller recommended policy
-        # (https://github.com/aws-controllers-k8s/iam-controller). Notably
-        # includes the List/Get/Put/Delete RolePolicy actions the controller
-        # uses when inspecting a role during reconciliation and deletion.
+        # (https://github.com/aws-controllers-k8s/iam-controller), scoped down
+        # to the role names this lab's RGD generates
+        # ("<table-name>-iam-role"). Notably includes the List/Get/Put/Delete
+        # RolePolicy actions the controller uses when inspecting a role during
+        # reconciliation and deletion.
         Sid    = "ManageAckRoles"
         Effect = "Allow"
         Action = [
@@ -177,10 +179,22 @@ resource "aws_iam_role_policy" "ack_capability_iam" {
           "iam:ListRolePolicies",
           "iam:GetRolePolicy",
           "iam:PutRolePolicy",
-          "iam:DeleteRolePolicy",
-          "iam:PassRole"
+          "iam:DeleteRolePolicy"
         ]
-        Resource = "*"
+        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.carts_dynamo_table_name}-*"
+      },
+      {
+        # The RGD-generated role is only ever passed to EKS Pod Identity, so
+        # constrain PassRole to that service in addition to the name scope.
+        Sid      = "PassAckRolesToPodIdentity"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.carts_dynamo_table_name}-*"
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "pods.eks.amazonaws.com"
+          }
+        }
       },
       {
         Sid    = "ManageAckPolicies"
@@ -197,7 +211,7 @@ resource "aws_iam_role_policy" "ack_capability_iam" {
           "iam:UntagPolicy",
           "iam:ListPolicyTags"
         ]
-        Resource = "*"
+        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.carts_dynamo_table_name}-*"
       }
     ]
   })
@@ -213,6 +227,7 @@ resource "aws_iam_role_policy" "ack_capability_eks" {
     Version = "2012-10-17"
     Statement = [
       {
+        # Scoped to this lab's cluster and its pod identity associations.
         Sid    = "ManagePodIdentityAssociations"
         Effect = "Allow"
         Action = [
@@ -224,7 +239,10 @@ resource "aws_iam_role_policy" "ack_capability_eks" {
           "eks:TagResource",
           "eks:UntagResource"
         ]
-        Resource = "*"
+        Resource = [
+          "arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${var.addon_context.eks_cluster_id}",
+          "arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:podidentityassociation/${var.addon_context.eks_cluster_id}/*"
+        ]
       }
     ]
   })

--- a/manifests/modules/automation/controlplanes/kro/.workshop/terraform/main.tf
+++ b/manifests/modules/automation/controlplanes/kro/.workshop/terraform/main.tf
@@ -92,40 +92,291 @@ resource "kubernetes_manifest" "ui_alb" {
   }
 }
 
-module "eks_ack_addons" {
-  source = "aws-ia/eks-ack-addons/aws"
+# EKS Capabilities run the ACK controllers in AWS-managed infrastructure and
+# assume a dedicated IAM "capability role" trusted by the
+# capabilities.eks.amazonaws.com service principal (instead of IRSA). Unlike the
+# ACK lab, the kro lab drives THREE ACK controllers from its
+# ResourceGraphDefinition, so the single capability role must be able to act as
+# all three:
+#   * DynamoDB  -> create/manage the carts Table
+#   * IAM       -> create the Policy + Role the pods assume for table access
+#   * EKS       -> create the Pod Identity Association that binds them
+resource "aws_iam_role" "ack_capability" {
+  name = "${var.addon_context.eks_cluster_id}-ack-capability"
 
-  # Cluster Info
-  cluster_name      = var.addon_context.eks_cluster_id
-  cluster_endpoint  = var.addon_context.aws_eks_cluster_endpoint
-  oidc_provider_arn = var.addon_context.eks_oidc_provider_arn
-
-  # ECR Credentials
-  ecrpublic_username = data.aws_ecrpublic_authorization_token.token.user_name
-  ecrpublic_token    = data.aws_ecrpublic_authorization_token.token.password
-
-  # Controllers to enable
-  enable_dynamodb = true
-  enable_iam      = true
-  enable_eks      = true
-  dynamodb = {
-    wait        = true
-    role_name   = "${var.addon_context.eks_cluster_id}-ack-dynamo"
-    policy_name = "${var.addon_context.eks_cluster_id}-ack-dynamo"
-  }
-
-  iam = {
-    wait        = true
-    role_name   = "${var.addon_context.eks_cluster_id}-ack-iam"
-    policy_name = "${var.addon_context.eks_cluster_id}-ack-iam"
-  }
-
-  eks = {
-    wait        = true
-    role_name   = "${var.addon_context.eks_cluster_id}-ack-eks"
-    policy_name = "${var.addon_context.eks_cluster_id}-ack-eks"
-  }
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "capabilities.eks.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
+      }
+    ]
+  })
 
   tags = var.tags
+}
 
+# DynamoDB controller: manage the carts table this lab provisions.
+resource "aws_iam_role_policy" "ack_capability_dynamodb" {
+  name = "ack-dynamodb"
+  role = aws_iam_role.ack_capability.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllAPIActionsOnCart"
+        Effect = "Allow"
+        Action = "dynamodb:*"
+        Resource = [
+          "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.carts_dynamo_table_name}",
+          "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.carts_dynamo_table_name}/index/*"
+        ]
+      }
+    ]
+  })
+}
+
+# IAM controller: create/manage the Policy and Role the RGD generates for the
+# carts pods, and pass that role to the Pod Identity Association.
+resource "aws_iam_role_policy" "ack_capability_iam" {
+  name = "ack-iam"
+  role = aws_iam_role.ack_capability.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Role + inline/attached-policy actions the ACK iam-controller needs to
+        # create, reconcile, and delete the Role its RGD defines. Mirrors the
+        # role/policy subset of the ACK iam-controller recommended policy
+        # (https://github.com/aws-controllers-k8s/iam-controller). Notably
+        # includes the List/Get/Put/Delete RolePolicy actions the controller
+        # uses when inspecting a role during reconciliation and deletion.
+        Sid    = "ManageAckRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:UpdateRole",
+          "iam:UpdateAssumeRolePolicy",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:ListRoleTags",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:PassRole"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ManageAckPolicies"
+        Effect = "Allow"
+        Action = [
+          "iam:CreatePolicy",
+          "iam:DeletePolicy",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:TagPolicy",
+          "iam:UntagPolicy",
+          "iam:ListPolicyTags"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# EKS controller: create/manage the Pod Identity Association that lets the carts
+# pods assume the RGD-generated role.
+resource "aws_iam_role_policy" "ack_capability_eks" {
+  name = "ack-eks"
+  role = aws_iam_role.ack_capability.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ManagePodIdentityAssociations"
+        Effect = "Allow"
+        Action = [
+          "eks:CreatePodIdentityAssociation",
+          "eks:DeletePodIdentityAssociation",
+          "eks:DescribePodIdentityAssociation",
+          "eks:UpdatePodIdentityAssociation",
+          "eks:ListPodIdentityAssociations",
+          "eks:TagResource",
+          "eks:UntagResource"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# The managed ACK controllers authenticate to the cluster's Kubernetes API using
+# a cluster access entry tied to the capability role. We manage this access
+# entry (and the AWS-managed ACK access policy) explicitly in Terraform so it is
+# always created and destroyed together with the role. Otherwise, tearing the
+# lab down and recreating it leaves a stale access entry bound to the previous
+# role, and the capability fails to start with an "Unauthorized" error.
+resource "aws_eks_access_entry" "ack_capability" {
+  cluster_name  = var.addon_context.eks_cluster_id
+  principal_arn = aws_iam_role.ack_capability.arn
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "ack_capability" {
+  cluster_name  = var.addon_context.eks_cluster_id
+  principal_arn = aws_iam_role.ack_capability.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSACKPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.ack_capability]
+}
+
+# IAM is eventually consistent, so allow the newly created capability role and
+# its trust policy to propagate before EKS validates it during capability
+# creation. Without this, CreateCapability can fail with an
+# "invalid trust policy" error even though the policy is correct.
+resource "time_sleep" "wait_for_capability_role" {
+  depends_on = [
+    aws_iam_role.ack_capability,
+    aws_iam_role_policy.ack_capability_dynamodb,
+    aws_iam_role_policy.ack_capability_iam,
+    aws_iam_role_policy.ack_capability_eks,
+  ]
+
+  create_duration = "30s"
+}
+
+# Enable the fully managed AWS Controllers for Kubernetes (ACK) capability.
+# Amazon EKS installs the ACK CRDs into the cluster as the capability becomes
+# active; no controller is deployed into the cluster itself.
+resource "aws_eks_capability" "ack" {
+  cluster_name              = var.addon_context.eks_cluster_id
+  capability_name           = "ack"
+  type                      = "ACK"
+  role_arn                  = aws_iam_role.ack_capability.arn
+  delete_propagation_policy = "RETAIN"
+
+  depends_on = [
+    time_sleep.wait_for_capability_role,
+    aws_eks_access_policy_association.ack_capability,
+  ]
+
+  tags = var.tags
+}
+
+# The kro capability runs the Kube Resource Orchestrator in AWS-managed
+# infrastructure, replacing the previous in-cluster `helm install kro` step.
+# Unlike ACK, the kro capability role needs NO IAM permissions -- kro only
+# interacts with the Kubernetes API, so the role exists purely for the
+# capabilities.eks.amazonaws.com trust relationship.
+resource "aws_iam_role" "kro_capability" {
+  name = "${var.addon_context.eks_cluster_id}-kro-capability"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "capabilities.eks.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# AmazonEKSKROPolicy lets the capability manage ResourceGraphDefinitions and
+# their instances. EKS creates this access entry automatically, but we manage it
+# in Terraform so it is created and destroyed together with the role and does not
+# leave a stale entry across lab teardown/recreate cycles.
+resource "aws_eks_access_entry" "kro_capability" {
+  cluster_name  = var.addon_context.eks_cluster_id
+  principal_arn = aws_iam_role.kro_capability.arn
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "kro_capability" {
+  cluster_name  = var.addon_context.eks_cluster_id
+  principal_arn = aws_iam_role.kro_capability.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSKROPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.kro_capability]
+}
+
+# AmazonEKSKROPolicy only grants permission to manage RGDs themselves. To let kro
+# create the underlying resources its RGDs define -- Deployments, Services, and
+# the ACK custom resources (Table, Policy, Role, PodIdentityAssociation) -- the
+# capability role needs broader cluster access. For this workshop we grant
+# AmazonEKSClusterAdminPolicy, which AWS recommends for getting-started/dev
+# scenarios. Production users should scope this to a custom RBAC policy.
+resource "aws_eks_access_policy_association" "kro_capability_admin" {
+  cluster_name  = var.addon_context.eks_cluster_id
+  principal_arn = aws_iam_role.kro_capability.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.kro_capability]
+}
+
+# Allow the kro capability role to propagate before EKS validates it during
+# capability creation (IAM is eventually consistent).
+resource "time_sleep" "wait_for_kro_capability_role" {
+  depends_on = [aws_iam_role.kro_capability]
+
+  create_duration = "30s"
+}
+
+# Enable the fully managed Kube Resource Orchestrator (kro) capability. Amazon
+# EKS installs the kro CRDs (ResourceGraphDefinition) into the cluster as the
+# capability becomes active; no kro controller is deployed into the cluster.
+resource "aws_eks_capability" "kro" {
+  cluster_name              = var.addon_context.eks_cluster_id
+  capability_name           = "kro"
+  type                      = "KRO"
+  role_arn                  = aws_iam_role.kro_capability.arn
+  delete_propagation_policy = "RETAIN"
+
+  depends_on = [
+    time_sleep.wait_for_kro_capability_role,
+    aws_eks_access_policy_association.kro_capability,
+    aws_eks_access_policy_association.kro_capability_admin,
+  ]
+
+  tags = var.tags
 }

--- a/manifests/modules/automation/controlplanes/kro/.workshop/terraform/outputs.tf
+++ b/manifests/modules/automation/controlplanes/kro/.workshop/terraform/outputs.tf
@@ -1,8 +1,6 @@
 output "environment_variables" {
   description = "Environment variables to be added to the IDE shell"
   value = {
-    DYNAMO_ACK_VERSION = var.dynamo_ack_version,
-    KRO_VERSION        = var.kro_version,
-    ACCOUNT_ID         = data.aws_caller_identity.current.account_id
+    ACCOUNT_ID = data.aws_caller_identity.current.account_id
   }
 }

--- a/manifests/modules/automation/controlplanes/kro/.workshop/terraform/vars.tf
+++ b/manifests/modules/automation/controlplanes/kro/.workshop/terraform/vars.tf
@@ -34,19 +34,12 @@ variable "resources_precreated" {
   type        = bool
 }
 
-variable "dynamo_ack_version" {
-  description = "The version of Dynamo ACK to use"
+variable "carts_dynamo_table_name" {
+  description = "Name of the DynamoDB table the kro RGD provisions for the carts application"
   type        = string
-  # renovate: datasource=github-releases depName=aws-controllers-k8s/dynamodb-controller
-  default = "1.7.1"
+  default     = "eks-workshop-carts-kro"
 }
 
-variable "kro_version" {
-  description = "The version of Kro to use"
-  type        = string
-  # renovate: datasource=github-releases depName=kro-run/kro
-  default = "0.8.4"
-}
 # tflint-ignore: terraform_unused_declarations
 variable "inbound_cidrs" {
   description = "CIDR range to allowlist for inbound traffic"

--- a/manifests/modules/automation/controlplanes/kro/rgds/webapp-dynamodb-rgd.yaml
+++ b/manifests/modules/automation/controlplanes/kro/rgds/webapp-dynamodb-rgd.yaml
@@ -38,6 +38,15 @@ spec:
 
   resources:
     - id: podIdentityAssociation
+      # The EKS Pod Identity API is eventually consistent: the association can be
+      # created in ACK before EKS will actually inject credentials for a pod using
+      # this service account. Pod Identity credentials are only injected at pod
+      # admission, so a carts pod admitted before the association is usable would
+      # start with the node role and fail on DynamoDB access. Gate on
+      # ACK.ResourceSynced=True so kro does not create the dependent WebApplication
+      # (and its Deployment) until the association has been reconciled in AWS.
+      readyWhen:
+        - ${podIdentityAssociation.status.conditions.exists(c, c.type == "ACK.ResourceSynced" && c.status == "True")}
       template:
         apiVersion: eks.services.k8s.aws/v1alpha1
         kind: PodIdentityAssociation

--- a/website/docs/automation/controlplanes/kro/cloud-dynamodb.md
+++ b/website/docs/automation/controlplanes/kro/cloud-dynamodb.md
@@ -116,6 +116,17 @@ $ aws dynamodb list-tables
 
 Our DynamoDB table and component have been successfully created using kro's composable approach.
 
+:::info EKS Pod Identity is eventually consistent
+The `WebApplicationDynamoDB` ResourceGraphDefinition gates the application Deployment on the `PodIdentityAssociation` reaching a synced state (via kro's `readyWhen`), because Pod Identity credentials are only injected when a pod is first admitted. If the `carts` pod ever lands in `CrashLoopBackOff` with a DynamoDB `AccessDenied` error, the association had not fully propagated when the pod started — simply recreate the pod so it picks up the injected credentials:
+
+```bash
+$ kubectl rollout restart deployment/carts -n carts
+$ kubectl rollout status deployment/carts -n carts --timeout=120s
+```
+
+For managing this eventual consistency at scale with automated GitOps tooling, see [How to manage EKS Pod Identities at scale using Argo CD and AWS ACK](https://aws.amazon.com/blogs/containers/how-to-manage-eks-pod-identities-at-scale-using-argo-cd-and-aws-ack/).
+:::
+
 To verify that the component is working with the new DynamoDB table, we can interact with it through a browser. An NLB has been created to expose the sample application for testing:
 
 ```bash

--- a/website/docs/automation/controlplanes/kro/index.md
+++ b/website/docs/automation/controlplanes/kro/index.md
@@ -16,7 +16,7 @@ $ prepare-environment automation/controlplanes/kro
 
 This will make the following changes to your lab environment:
 
-- Install the AWS Controllers for Kubernetes controllers for EKS, IAM and DynamoDB
+- Enable the fully managed Amazon EKS ACK (AWS Controllers for Kubernetes) capability, which provides the EKS, IAM and DynamoDB controllers
 - Install the AWS Load Balancer Controller
 - Create an Ingress resource for the UI workload
 

--- a/website/docs/automation/controlplanes/kro/introduction.md
+++ b/website/docs/automation/controlplanes/kro/introduction.md
@@ -5,35 +5,28 @@ sidebar_position: 3
 
 kro operates within a cluster using two primary components:
 
-1. The kro controller manager, which provides the core orchestration functionality
+1. The kro controller, which provides the core orchestration functionality
 2. ResourceGraphDefinitions (RGDs), which define templates for creating groups of related resources
 
-The kro controller manager watches for ResourceGraphDefinition custom resources and orchestrates the creation and management of the underlying Kubernetes resources defined in the template.
+The kro controller watches for ResourceGraphDefinition custom resources and orchestrates the creation and management of the underlying Kubernetes resources defined in the template.
 
 kro simplifies complex resource management by allowing platform teams to define ResourceGraphDefinitions that encapsulate multiple related resources. Developers interact with simple custom APIs defined by the RGD schema, while kro handles the complexity of creating and managing the underlying resources. This architecture provides a clear separation between the platform team, who defines the ResourceGraphDefinitions, and application developers, who consume the simplified custom APIs to create complex resource groups.
 
-Let us first install kro to the Kubernetes cluster by using a Helm chart:
+In this lab kro is provided as a fully managed [Amazon EKS Capability](https://docs.aws.amazon.com/eks/latest/userguide/eks-capabilities.html), which was enabled when you prepared the environment. Amazon EKS runs the kro controller in AWS-managed infrastructure and installs the kro custom resource definitions into your cluster, so there is no controller to install, patch, or scale yourself.
 
-```bash wait=60
-$ helm install kro oci://registry.k8s.io/kro/charts/kro \
-  --version=${KRO_VERSION} \
-  --namespace kro-system --create-namespace \
-  --wait
-```
-
-Verify the kro controller is running:
-
-```bash
-$ kubectl get deployment -n kro-system
-NAME    READY   UP-TO-DATE   AVAILABLE   AGE
-kro     1/1     1            1           13s
-```
-
-We can also verify that the kro custom resource definitions have been installed:
+Verify that the kro custom resource definitions have been installed by the capability:
 
 ```bash
 $ kubectl get crd | grep kro
+graphrevisions.internal.kro.run           2025-10-15T22:34:13Z
 resourcegraphdefinitions.kro.run          2025-10-15T22:34:13Z
+```
+
+Because kro runs as a managed capability, there is no kro controller deployment inside the cluster:
+
+```bash
+$ kubectl get deployment -n kro-system
+No resources found in kro-system namespace.
 ```
 
 When you create a ResourceGraphDefinition kro performs the following:

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/automation/controlplanes/kro/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/automation/controlplanes/kro/index.md
@@ -17,7 +17,7 @@ $ prepare-environment automation/controlplanes/kro
 
 これにより、ラボ環境に以下の変更が加えられます：
 
-- EKS、IAM、DynamoDB 用の AWS Controllers for Kubernetes コントローラーをインストール
+- EKS、IAM、DynamoDB コントローラーを提供する、フルマネージドの Amazon EKS ACK（AWS Controllers for Kubernetes）機能を有効化
 - AWS Load Balancer Controller をインストール
 - UI ワークロード用の Ingress リソースを作成
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/automation/controlplanes/kro/introduction.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/automation/controlplanes/kro/introduction.md
@@ -6,35 +6,28 @@ tmdTranslationSourceHash: f9fdd7f9d4f4dd982e2626362769a8c2
 
 kro はクラスター内で2つの主要コンポーネントを使用して動作します：
 
-1. kro コントローラーマネージャー（コアのオーケストレーション機能を提供）
+1. kro コントローラー（コアのオーケストレーション機能を提供）
 2. ResourceGraphDefinitions（RGDs）（関連リソースのグループを作成するためのテンプレートを定義）
 
-kro コントローラーマネージャーは ResourceGraphDefinition カスタムリソースを監視し、テンプレートで定義された基盤となる Kubernetes リソースの作成と管理をオーケストレーションします。
+kro コントローラーは ResourceGraphDefinition カスタムリソースを監視し、テンプレートで定義された基盤となる Kubernetes リソースの作成と管理をオーケストレーションします。
 
 kro は、プラットフォームチームが複数の関連リソースをカプセル化する ResourceGraphDefinitions を定義できるようにすることで、複雑なリソース管理を簡素化します。開発者は RGD スキーマによって定義されたシンプルなカスタム API を操作し、kro が基礎となるリソースの作成と管理の複雑さを処理します。このアーキテクチャにより、ResourceGraphDefinitions を定義するプラットフォームチームと、複雑なリソースグループを作成するためのシンプルなカスタム API を消費するアプリケーション開発者との間に明確な分離が提供されます。
 
-まず、Helm チャートを使用して kro を Kubernetes クラスターにインストールしましょう：
+このラボでは、kro はフルマネージドの [Amazon EKS 機能（Capability）](https://docs.aws.amazon.com/eks/latest/userguide/eks-capabilities.html) として提供され、環境の準備時に有効化されています。Amazon EKS は kro コントローラーを AWS マネージドインフラストラクチャで実行し、kro のカスタムリソース定義をクラスターにインストールするため、コントローラーを自分でインストール、パッチ適用、スケーリングする必要はありません。
 
-```bash wait=60
-$ helm install kro oci://registry.k8s.io/kro/charts/kro \
-  --version=${KRO_VERSION} \
-  --namespace kro-system --create-namespace \
-  --wait
-```
-
-kro コントローラーが実行されていることを確認します：
-
-```bash
-$ kubectl get deployment -n kro-system
-NAME    READY   UP-TO-DATE   AVAILABLE   AGE
-kro     1/1     1            1           13s
-```
-
-また、kro カスタムリソース定義がインストールされていることも確認できます：
+kro のカスタムリソース定義が機能によってインストールされていることを確認します：
 
 ```bash
 $ kubectl get crd | grep kro
+graphrevisions.internal.kro.run           2025-10-15T22:34:13Z
 resourcegraphdefinitions.kro.run          2025-10-15T22:34:13Z
+```
+
+kro はマネージド機能として実行されるため、クラスター内に kro コントローラーのデプロイメントは存在しません：
+
+```bash
+$ kubectl get deployment -n kro-system
+No resources found in kro-system namespace.
 ```
 
 ResourceGraphDefinition を作成すると、kro は以下を実行します：


### PR DESCRIPTION
# PR Description

## What

Converts the `automation/controlplanes/kro` lab from self-managed controllers to fully managed **Amazon EKS Capabilities**:

- **kro** — replaces the in-cluster `helm install kro` step with a managed capability (`type = KRO`). Amazon EKS runs the kro controller and installs the kro CRDs; there is no controller to install, patch, or scale in-cluster.
- **ACK** — replaces the self-managed `aws-ia/eks-ack-addons` Helm/IRSA controllers with a managed capability (`type = ACK`) for the DynamoDB, IAM, and EKS controllers this lab's ResourceGraphDefinition uses.

This follows the pattern established for the ACK lab in #1870, extended to also cover kro itself.

## Why

EKS Capabilities let Amazon manage the availability, patching, and scaling of kro and ACK, removing the Helm/IRSA setup and version pinning the lab previously maintained. It also showcases the managed capability model that this lab is meant to teach.

## Changes

**Terraform** (`manifests/modules/automation/controlplanes/kro/.workshop/terraform/`)

- `main.tf` — remove the `eks_ack_addons` module; add two `aws_eks_capability` resources (ACK + KRO), each with a capability IAM role trusted by `capabilities.eks.amazonaws.com`, cluster access entries, and IAM-propagation waits. The ACK capability role carries the DynamoDB/IAM/EKS permissions the RGD's controllers need; the KRO capability role needs no IAM permissions and is granted `AmazonEKSKROPolicy` + `AmazonEKSClusterAdminPolicy` so kro can create the resources its RGDs define.
- `vars.tf` — remove `dynamo_ack_version` and `kro_version`; add `carts_dynamo_table_name`.
- `outputs.tf` — drop the removed version variables.

**Content** (English + Japanese)

- `index.md` — update the prepare-environment summary to describe the managed ACK capability.
- `introduction.md` — remove the `helm install kro` step; explain kro is now provided by the managed EKS Capability.

## Testing

Validated end-to-end on a workshop cluster created with `make create-infrastructure`:

- `prepare-environment automation/controlplanes/kro` completes successfully; both capabilities reach **ACTIVE** (`ack`, `kro`).
- kro CRDs are installed by the capability with **no** Helm release and **no** controller pod in `kro-system`.
- Applying the `WebApplicationDynamoDB` RGD instance provisions all four ACK resources (DynamoDB `Table`, IAM `Policy` + `Role`, EKS `PodIdentityAssociation`), all reaching `ACK.ResourceSynced=True`, and the carts application connects to the DynamoDB table.
- `terraform fmt` and `terraform validate` pass.

## Notes

- The `AmazonEKSClusterAdminPolicy` granted to the kro capability role follows the AWS "getting started / development" guidance for kro capabilities. Happy to scope this to a narrower custom policy if preferred for the workshop.