### PR TITLE
fix: correct invalid .mergify.yml empty rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,1 +1,1 @@
-pull_request_rules:[]
+pull_request_rules: []


### PR DESCRIPTION
## What

`.mergify.yml` currently contains:

```yaml
pull_request_rules:[]
```

Without a space after the colon, YAML parses `pull_request_rules:[]` as a **scalar string**, not an empty list. Mergify rejects it on every PR with:

> The current Mergify configuration is invalid — Invalid YAML @ root → pull_request_rules:[] — Value is not a valid dict

## Fix

One character — add the space so it's a valid empty list:

```yaml
pull_request_rules: []
```

This preserves the intent (Mergify enabled, no rules) while clearing the 'Mergify Merge Queue' / 'Summary' check failures that currently block the merge queue on all PRs.

Introduced in c12841a8 (Update .mergify.yml).