### PR TITLE
fix: resolve pre-commit hook failure with language: node assertion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   - repo: local
     hooks:
       - id: lint
-        language: node
+        language: system
         name: Run linting
         entry: yarn lint:staged
-        stage: [commit]
+        stages: [pre-commit]


### PR DESCRIPTION
Cherry-pick of commit da3c5ef from PR #1858.

Fixes the pre-commit hook failure by changing `language: node` to `language: system` for the local lint hook, since yarn is already available in the CI environment. Also updates deprecated `stage: [commit]` to `stages: [pre-commit]` per current pre-commit schema.