### PR TITLE
fix: awslabs.eks-mcp-server failing to start

### DIFF
--- a/manifests/modules/aiml/kiro-cli/setup/eks-mcp.json
+++ b/manifests/modules/aiml/kiro-cli/setup/eks-mcp.json
@@ -3,7 +3,7 @@
     "awslabs.eks-mcp-server": {
       "command": "uvx",
       "args": [
-        "awslabs.eks-mcp-server@0.1.32",
+        "awslabs.eks-mcp-server@latest",
         "--allow-write",
         "--allow-sensitive-data-access"
       ],


### PR DESCRIPTION
Pinning a fixed version creates incompatibility with MCP SDK. Replacing the fixed version @0.1.32 with @latest solves the problem of EKS MCP server getting errored out during the startup process.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:
This PR is required to make kiro-cli working with EKS MCP server.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
