### PR TITLE
fix: Resolve EKS Auto Mode version dynamically

### DIFF
--- a/cluster/eksctl/cluster-auto.yaml
+++ b/cluster/eksctl/cluster-auto.yaml
@@ -7,11 +7,13 @@ availabilityZones:
 metadata:
   name: ${EKS_CLUSTER_AUTO_NAME}
   region: ${AWS_REGION}
-  version: "1.33"
+  version: latest
   tags:
     karpenter.sh/discovery: ${EKS_CLUSTER_AUTO_NAME}
     created-by: eks-workshop-v2
     env: ${EKS_CLUSTER_AUTO_NAME}
+upgradePolicy:
+  supportType: STANDARD
 vpc:
   cidr: 10.43.0.0/16
   clusterEndpoints:


### PR DESCRIPTION
#### What this PR does / why we need it:

The Auto Mode cluster config pins Kubernetes 1.33. New workshop environments keep creating that version after it enters EKS extended support.

EKS extended support adds a per-cluster-hour charge on top of the standard cluster fee. A stale version pin therefore increases the cost of every workshop cluster that remains running after that version leaves standard support.

This changes `metadata.version` to eksctl's `latest` resolver and sets `upgradePolicy.supportType` to `STANDARD`. New Auto Mode clusters will resolve the newest version available in their region and automatically upgrade instead of entering paid extended support.

#### Which issue(s) this PR fixes:

N/A

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (not applicable: this does not change workshop module content)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

#### Validation

- `eksctl 0.222.0 create cluster --dry-run` resolved `latest` to Kubernetes 1.36 in `us-west-2` and preserved `supportType: STANDARD`
- `yarn lint:staged --concurrent false --no-stash`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
