### PR TITLE
chore: use CONTAINER_CLI variable in Makefile instead of hardcoded docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ shell_command=''
 shell_simple_command=''
 glob='-'
 cluster='all'
+CONTAINER_CLI ?= docker
 
 .PHONY: install
 install:
@@ -56,13 +57,13 @@ pre-provision:
 
 .PHONY: create-infrastructure
 create-infrastructure:
-	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-	bash hack/create-infrastructure.sh $(environment) $(cluster)
+	aws ecr-public get-login-password --region us-east-1 | $(CONTAINER_CLI) login --username AWS --password-stdin public.ecr.aws
+	CONTAINER_CLI=$(CONTAINER_CLI) bash hack/create-infrastructure.sh $(environment) $(cluster)
 
 .PHONY: destroy-infrastructure
 destroy-infrastructure:
-	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-	bash hack/destroy-infrastructure.sh $(environment) $(cluster)
+	aws ecr-public get-login-password --region us-east-1 | $(CONTAINER_CLI) login --username AWS --password-stdin public.ecr.aws
+	CONTAINER_CLI=$(CONTAINER_CLI) bash hack/destroy-infrastructure.sh $(environment) $(cluster)
 
 .PHONY: deploy-ide
 deploy-ide:


### PR DESCRIPTION
Default to finch and pass CONTAINER_CLI through to hack scripts so create-infrastructure and destroy-infrastructure work without docker.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
