### PR TITLE
fix: replace fixed sleep with retry loop for pod log readiness

### DIFF
--- a/website/docs/fastpaths/developer/amazon-eks-pod-identity/understanding.md
+++ b/website/docs/fastpaths/developer/amazon-eks-pod-identity/understanding.md
@@ -7,8 +7,8 @@ The first place to look for the issue is the logs of the `carts` service:
 
 ```bash hook=pod-logs timeout=480
 $ LATEST_POD=$(kubectl get pods -n carts -l app.kubernetes.io/component=service --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
-sleep 60
-kubectl logs -n carts -p $LATEST_POD
+$ for i in $(seq 1 24); do kubectl logs -n carts -p $LATEST_POD 2>/dev/null && break || sleep 5; done
+$ kubectl logs -n carts -p $LATEST_POD
 [...]
 software.amazon.awssdk.core.exception.SdkClientException: Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain(credentialsProviders=[SystemPropertyCredentialsProvider(), EnvironmentVariableCredentialsProvider(), WebIdentityTokenCredentialsProvider(), ProfileCredentialsProvider(profileName=default, profileFile=ProfileFile(sections=[])), ContainerCredentialsProvider(), InstanceProfileCredentialsProvider()]) : [SystemPropertyCredentialsProvider(): Unable to load credentials from system settings. Access key must be specified either via environment variable (AWS_ACCESS_KEY_ID) or system property (aws.accessKeyId)., EnvironmentVariableCredentialsProvider(): Unable to load credentials from system settings. Access key must be specified either via environment variable (AWS_ACCESS_KEY_ID) or system property (aws.accessKeyId)., WebIdentityTokenCredentialsProvider(): Either the environment variable AWS_WEB_IDENTITY_TOKEN_FILE or the javaproperty aws.webIdentityTokenFile must be set., ProfileCredentialsProvider(profileName=default, profileFile=ProfileFile(sections=[])): Profile file contained no credentials for profile 'default': ProfileFile(sections=[]), ContainerCredentialsProvider(): Cannot fetch credentials from container - neither AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variables are set., InstanceProfileCredentialsProvider(): Failed to load credentials from IMDS.]
 ```


### PR DESCRIPTION
Replace the static 60s sleep with a polling loop that checks every 5s (up to 2 minutes) for previous pod logs to become available before proceeding.

This fixes a reliability issue in the Pod Identity understanding page where a fixed sleep could be too short (pod hasn't crashed yet) or unnecessarily long.