### PR TITLE
fix: Scope the Identity Center depends_on to the modules that need it

### DIFF
--- a/hack/pre-provision-resources.sh
+++ b/hack/pre-provision-resources.sh
@@ -94,8 +94,16 @@ done < <(find $manifests_dir/modules -type d -name "preprovision" -print0)
 #
 # One root also means Terraform is free to reorder, and a module reading Identity
 # Center through a data source could be evaluated before the layer that creates it.
-# Hence the explicit depends_on on every wrapper below. It costs nothing for the
-# modules that do not care, and without it the ordering is luck.
+# Hence the explicit depends_on on the wrappers below -- but only on the modules that
+# declare `.requires-idc`, because it is not free for the ones that do not.
+#
+# A module-level depends_on propagates to every data source inside the module, and a
+# data source that depends on something not yet applied cannot be read during plan.
+# Its result is therefore unknown until apply, which is fatal to any `count` or
+# `for_each` derived from it -- `count = length(data.aws_subnets.<x>.ids)` fails with
+# "Invalid count argument". Applying the depends_on to every wrapper broke unrelated
+# modules that way (the EFS mount targets in fundamentals/storage/efs), so it is
+# scoped to the modules whose ordering actually depends on the shared layer.
 if [ -n "$idc_required" ]; then
   cp -R $idc_base_dir $conf_dir/$idc_base_target
 
@@ -122,7 +130,7 @@ do
   cp -R $file $conf_dir/$target
 
   depends_on_idc=""
-  if [ -n "$idc_required" ]; then
+  if [ -n "$idc_required" ] && [ -f "$file/.requires-idc" ]; then
     depends_on_idc="
   depends_on = [module.gen_idc_base]
 "


### PR DESCRIPTION
#### What this PR does / why we need it:

Event provisioning currently fails during pre-provisioning with:

```
Error: Invalid count argument
  on fundamentals_storage-<hash>/main.tf line 66,
  in resource "aws_efs_mount_target" "efsmtpvsubnet":
  66:   count = length(data.aws_subnets.private_efs.ids)

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
make: *** [Makefile:90: pre-provision] Error 1
```

`hack/pre-provision-resources.sh` stages every `**/.workshop/terraform/preprovision`
directory as a module in a single Terraform root. When **any** staged module declares
`.requires-idc`, the script added `depends_on = [module.gen_idc_base]` to **every**
module wrapper.

A module-level `depends_on` propagates to the data sources inside that module, and a
data source that depends on something not yet applied cannot be read during plan — its
result is unknown until apply, which is fatal to any `count`/`for_each` derived from it.
The EFS pre-provision module has nothing to do with Identity Center; it was simply
ordered after a layer it never reads, and its mount-target `count` became unknown.

This gates the `depends_on` on the module's own `.requires-idc` marker. Ordering for the
modules that genuinely read Identity Center (`automation/gitops/argocd` and
`fastpaths/developers`) is unchanged; every other module plans as it did before. The
stale comment claiming the blanket `depends_on` "costs nothing for the modules that do
not care" is replaced with an explanation of the plan-time deferral, so it is not
reintroduced.

Neither IDC-requiring module derives a `count`/`for_each` from a data source
(`fastpaths/developers` drives all 23 of its `count` expressions from
`var.enable_eks_capabilities`), so scoping is sufficient. Across all preprovision
directories, `count = length(data...)` appears exactly once — the EFS mount targets.

Introduced in #1858, which added both the injection and the two `.requires-idc` markers
in the same change.

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

Validated against real Workshop Studio events rather than `make test`, since the failure
is in event pre-provisioning and not reachable from a module test:

- **Before:** a team deploying build `2198bc60` failed with the error above after ~29 min
  (`teamstack` → `EksctlRunnerClusterStack` `CREATE_FAILED`).
- **After:** re-running the same CodeBuild project on the fixed branch succeeded in
  19m32s with `Apply complete! Resources: 87 added, 0 changed, 0 destroyed`, all three
  `aws_efs_mount_target.efsmtpvsubnet` created and zero `Invalid count argument` errors.
- A subsequent clean team deployment in the same event reached `deployment_success` on the
  first attempt in 47 min, with `module.gen_idc_base` applying normally — confirming the
  ordering the `depends_on` exists to guarantee is still intact.
