### PR TITLE
fix: Validate the module path passed to prepare-environment

### DIFF
--- a/lab/bin/reset-environment
+++ b/lab/bin/reset-environment
@@ -108,6 +108,34 @@ if [ ! -z "${REPOSITORY_REF}" ] && [ -z "${RESET_NO_DELETE}" ]; then
 fi
 
 if [ ! -z "$module" ]; then
+  # The module directory is the registry of valid module names. reset-environment
+  # derives the manifests, the cleanup hook and the Terraform to apply from this
+  # path, and reports the name to analytics, so a path that does not exist would
+  # otherwise reset the environment, install nothing and still report success.
+  #
+  # Checked here because $manifests_path is only populated by the repository
+  # refresh above, and before anything is torn down so a bad path costs nothing.
+  # Labs with no manifests of their own register an empty directory to be found.
+  module_dir="$manifests_path/modules/$module"
+
+  if [[ "$module" == fastpaths/* ]]; then
+    # fastpaths content addresses a module by its first two path segments, and uses
+    # the singular form where the directory is plural (developer -> developers).
+    fastpaths_dir="$manifests_path/modules/$(echo "$module" | cut -d'/' -f1-2)"
+
+    if [ -d "$fastpaths_dir" ]; then
+      module_dir="$fastpaths_dir"
+    elif [ -d "${fastpaths_dir}s" ]; then
+      module_dir="${fastpaths_dir}s"
+    fi
+  fi
+
+  if [ ! -d "$module_dir" ]; then
+    logmessage "🚨 ${RED}Error:${NC} no module registered at manifests/modules/$module"
+    logmessage "Check the module path in this lab's prepare-environment command."
+    exit 1
+  fi
+
   ANALYTICS_ENDPOINT=${ANALYTICS_ENDPOINT:-""}
 
   if [ ! -z "$ANALYTICS_ENDPOINT" ]; then

--- a/manifests/modules/fastpaths/getting-started/.gitkeep
+++ b/manifests/modules/fastpaths/getting-started/.gitkeep
@@ -1,0 +1,3 @@
+# This lab has no manifests or .workshop assets, but its name is still a module:
+# prepare-environment reports it to analytics and reset-environment validates that
+# a directory exists here. Registering it keeps that validation a single rule.

--- a/manifests/modules/fundamentals/mng/basics/.gitkeep
+++ b/manifests/modules/fundamentals/mng/basics/.gitkeep
@@ -1,0 +1,3 @@
+# This lab has no manifests or .workshop assets, but its name is still a module:
+# prepare-environment reports it to analytics and reset-environment validates that
+# a directory exists here. Registering it keeps that validation a single rule.

--- a/manifests/modules/introduction/getting-started/.gitkeep
+++ b/manifests/modules/introduction/getting-started/.gitkeep
@@ -1,0 +1,3 @@
+# This lab has no manifests or .workshop assets, but its name is still a module:
+# prepare-environment reports it to analytics and reset-environment validates that
+# a directory exists here. Registering it keeps that validation a single rule.


### PR DESCRIPTION
#### What this PR does / why we need it:

`reset-environment` derives the manifests, the cleanup hook and the Terraform to apply
from `manifests/modules/$module`, and reports the name to the analytics endpoint
(`lab=$module`), but never checked that the path exists. It only ever acts
`if [ -f "$module_path/.workshop/..." ]`, so a path that does not exist resets the
environment, installs nothing, and still prints `✅ Environment is ready!` — a typo is
indistinguishable from success.

This is not hypothetical: `fundamentals/compute/managed-node-groups/basics` instructs
`prepare-environment fundamentals/mng/basics`, and there is no such module directory.
The lab happens to work because it only needs the default node group and the sample
app, but nothing would have told us otherwise.

**The check** runs after the repository refresh has populated `$manifests_path` and
before anything is torn down, so a bad path fails fast without leaving a half-reset
environment. It also runs before the analytics ping, so a failed run is not reported as
a lab start.

**Registering names instead of exempting them.** Three labs have no manifests or
`.workshop` assets of their own but are still module names the analytics endpoint
receives, so they register an empty directory with a `.gitkeep` (a convention already
used in `cluster/cdk` and `governance/working-groups`). That keeps the validation a
single rule rather than a growing list of special cases:

- `fundamentals/mng/basics`
- `introduction/getting-started`
- `fastpaths/getting-started`

The fastpaths branch is handled explicitly because that content addresses a module by
its first two path segments and uses the singular form where the directory is plural
(`developer` → `developers`).

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

Verified by extracting every `prepare-environment <module>` invocation from the content
— 58 distinct paths — and running the validation logic against each: all resolve with
the three registrations above, and a deliberate typo fails. The fastpaths
singular-to-plural fallback was confirmed on a case-sensitive filesystem in a live
Workshop Studio environment, along with `fundamentals/mng/basics` failing there before
its directory is registered.
