### PR TITLE
chore: Pin mcp-proxy-for-aws to 1.6.4

### DIFF
--- a/manifests/modules/aiml/kiro-cli/setup/eks-mcp.json
+++ b/manifests/modules/aiml/kiro-cli/setup/eks-mcp.json
@@ -5,7 +5,7 @@
       "type": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws@1.6.4",
         "https://eks-mcp.${AWS_REGION}.api.aws/mcp",
         "--service",
         "eks-mcp",
@@ -19,7 +19,7 @@
       "type": "stdio",
       "command": "uvx",
       "args": [
-        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws@1.6.4",
         "https://aws-mcp.us-east-1.api.aws/mcp",
         "--metadata",
         "AWS_REGION=${AWS_REGION}"


### PR DESCRIPTION
Pin the mcp-proxy-for-aws dependency for the eks-mcp and aws-mcp servers to version 1.6.4 instead of latest for reproducible behavior.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
