### PR TITLE
fix(troubleshooting): increase node recycle timeout in

### DIFF
--- a/website/docs/troubleshooting/workernodes/three.md
+++ b/website/docs/troubleshooting/workernodes/three.md
@@ -160,14 +160,14 @@ $ kubectl scale deployment/prod-app -n prod --replicas=0 && kubectl delete pod -
 
 #### 6.3. Recycle the node on the nodegroup
 
-```bash timeout=120 wait=95
+```bash timeout=600 wait=95
 $ aws eks update-nodegroup-config --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 --scaling-config desiredSize=0 && \
 aws eks wait nodegroup-active --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 && \
 aws eks update-nodegroup-config --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 --labels "addOrUpdateLabels={status=new-node}" && \
 aws eks wait nodegroup-active --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 && \
 aws eks update-nodegroup-config --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 --scaling-config desiredSize=1 && \
 aws eks wait nodegroup-active --cluster-name "${EKS_CLUSTER_NAME}" --nodegroup-name new_nodegroup_3 && \
-for i in {1..12}; do NODE_NAME_2=$(kubectl get nodes --selector=eks.amazonaws.com/nodegroup=new_nodegroup_3,status=new-node --no-headers -o custom-columns=":metadata.name" 2>/dev/null) && [ -n "$NODE_NAME_2" ] && break || sleep 5; done && \
+for i in {1..36}; do NODE_NAME_2=$(kubectl get nodes --selector=eks.amazonaws.com/nodegroup=new_nodegroup_3,status=new-node --no-headers -o custom-columns=":metadata.name" 2>/dev/null) && [ -n "$NODE_NAME_2" ] && break || sleep 5; done && \
 [ -n "$NODE_NAME_2" ]
 ```
 


### PR DESCRIPTION
The 'Node in Not-Ready state' scenario failed its automated test with 'Script failed to complete within 120 seconds'. Step 6.3 recycles the node group via three serial 'aws eks wait nodegroup-active' calls plus EC2 boot, which takes ~6 minutes in practice (observed ~5m47s), well beyond the 120s limit.

Raise the step timeout from 120 to 600 seconds and extend the node-appearance poll loop from 12 (60s) to 36 (180s) iterations so the recycle can complete within budget. Content/test-timing change only; no cluster or command logic changed.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
