### PR TITLE
fix(troubleshooting): alb not showing up

### DIFF
--- a/manifests/modules/troubleshooting/alb/.workshop/terraform/main.tf
+++ b/manifests/modules/troubleshooting/alb/.workshop/terraform/main.tf
@@ -113,8 +113,14 @@ resource "null_resource" "kustomize_app" {
     always_run = timestamp()
   }
 
+  # The ingress carries an `alb.ingress.kubernetes.io/inbound-cidrs` annotation
+  # templated as `$INBOUND_CIDRS`. Substitute it here (from the module's
+  # inbound_cidrs variable) so the AWS Load Balancer Controller receives a valid
+  # CIDR. Without substitution the controller fails model-building with
+  # "invalid CIDR address: $INBOUND_CIDRS" and never provisions the ALB, which
+  # masks the intended subnet-tag (alb_fix_1) and IAM (alb_fix_5) scenarios.
   provisioner "local-exec" {
-    command = "kubectl apply -k ~/environment/eks-workshop/modules/troubleshooting/alb/creating-alb"
+    command = "kubectl kustomize ~/environment/eks-workshop/modules/troubleshooting/alb/creating-alb | INBOUND_CIDRS='${var.inbound_cidrs}' envsubst '$INBOUND_CIDRS' | kubectl apply -f -"
     when    = create
   }
 


### PR DESCRIPTION
…ress

The troubleshooting/alb setup applied the ui ingress via a plain 'kubectl apply -k', so the 'alb.ingress.kubernetes.io/inbound-cidrs: $INBOUND_CIDRS' annotation was stored as a literal string. The AWS Load Balancer Controller then failed model-building on every reconcile with 'invalid CIDR address: $INBOUND_CIDRS', so the ALB was never created -- masking the intended subnet-tag (alb_fix_1) and IAM (alb_fix_5) scenarios and leaving alb_fix_5 Step 4 unable to show an ALB hostname.

Apply the ingress through envsubst using the module's inbound_cidrs variable (mirroring how alb_fix_7 applies fix_ingress) so a valid CIDR is baked in at setup. The backend service-ui / ui-app selector issues are left untouched for alb_fix_7.

Verified on a local deployment: after prepare-environment the annotation holds a real CIDR, the documented subnet/IAM errors surface as intended, and alb_fix_5 Step 4 returns an ALB hostname.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
