### PR TITLE
Update: Karpenter Introduction and Consolidation content refresh

### DIFF
--- a/website/docs/fundamentals/compute/karpenter/consolidation.md
+++ b/website/docs/fundamentals/compute/karpenter/consolidation.md
@@ -16,11 +16,11 @@ Disruption is configured through the `disruption` block in a `NodePool`. You can
 1. `expireAfter` is set to a custom value so that nodes are terminated automatically after 72 hours
 2. The `WhenEmptyOrUnderutilized` policy enables Karpenter to replace nodes when they are either empty or underutilized
 
-The `consolidationPolicy` can also be set to `WhenEmpty`, which restricts disruption only to nodes that contain no workload pods. Learn more about Disruption on the [Karpenter docs](https://karpenter.sh/docs/concepts/disruption/#consolidation).
+The `consolidationPolicy` can also be set to `WhenEmpty`, which restricts disruption only to nodes that contain no workload pods or `Balanced`, when the cost savings outweigh the disruption to running pods. Learn more about Disruption on the [Karpenter docs](https://karpenter.sh/docs/concepts/disruption/#consolidation).
 
 Scaling out infrastructure is only one side of the equation for operating compute infrastructure in a cost-effective manner. We also need to be able to optimize on an on-going basis such that, for example, workloads running on under-utilized compute instances are compacted to fewer instances. This improves the overall efficiency of how we run workloads on the compute, resulting in less overhead and lower costs.
 
-Let's explore how to trigger automatic consolidation when `disruption` is set to `consolidationPolicy: WhenUnderutilized`:
+Let's explore how to trigger automatic consolidation when `disruption` is set to `consolidationPolicy: WhenEmptyOrUnderutilized`:
 
 1. Scale the `inflate` workload from 5 to 12 replicas, triggering Karpenter to provision additional capacity
 2. Scale down the workload back down to 5 replicas

--- a/website/docs/fundamentals/compute/karpenter/index.md
+++ b/website/docs/fundamentals/compute/karpenter/index.md
@@ -31,5 +31,4 @@ Karpenter's goal is to improve the efficiency and cost of running workloads on K
 - Watching for pods that the Kubernetes scheduler has marked as unschedulable
 - Evaluating scheduling constraints (resource requests, node selectors, affinities, tolerations, and topology spread constraints) requested by the pods
 - Provisioning nodes that meet the requirements of the pods
-- Scheduling the pods to run on the new nodes
-- Removing the nodes when the nodes are no longer needed
+- Disrupting the nodes when the nodes are no longer needed


### PR DESCRIPTION
#### What this PR does / why we need it:

Updated content in the Karpenter module of EKS Workshop:

#### Which issue(s) this PR fixes:

- index.md:  
  Replaced the last two bullets describing what Karpenter does with a single, more accurate bullet:
  Before:
  "Scheduling the pods to run on the new nodes" 
  "Removing the nodes when the nodes are no longer needed"
 
After:
"Disrupting the nodes when the nodes are no longer needed"

- consolidation.md : 
 
  1. Expanded the description of consolidationPolicy options. The line about WhenEmpty now also mentions the Balanced option:

Before: "...set to WhenEmpty, which restricts disruption only to nodes that contain no workload pods."
After: "...set to WhenEmpty, which restricts disruption only to nodes that contain no workload pods or Balanced, when the cost savings outweigh the disruption to running pods."

2. Fixed an outdated policy name in the walkthrough intro:

Before: "...when disruption is set to consolidationPolicy: WhenUnderutilized"
After: "...when disruption is set to consolidationPolicy: WhenEmptyOrUnderutilized"
This aligns the prose with the actual policy value used earlier in the same file (WhenEmptyOrUnderutilized).

#### Quality checks

- [X] My content adheres to the style guidelines
- [X] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [X] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
