### PR TITLE
update: Fix typos and label inconsistency in Kubecost module

### DIFF
--- a/website/docs/observability/kubecost/costallocation.md
+++ b/website/docs/observability/kubecost/costallocation.md
@@ -18,7 +18,7 @@ We can use this screen to dive further into the cost allocation of our cluster. 
 - pod
 - labels
 
-The application we installed in the Introduction section created several of these components. These components also have. Next, we'll drill into the costs of this application by using these dimensions.
+The application we installed in the Introduction section created several of these components. Next, we'll drill into the costs of this application by using these dimensions.
 
 To do this click on the setting button next to <b>Aggregate by</b> at the top right.
 

--- a/website/docs/observability/kubecost/costallocation.md
+++ b/website/docs/observability/kubecost/costallocation.md
@@ -18,7 +18,7 @@ We can use this screen to dive further into the cost allocation of our cluster. 
 - pod
 - labels
 
-The application we installed in the Introduction section created several of these components. Next, we'll drill into the costs of this application by using these dimensions.
+The application we installed in the Introduction section created several of these components. These components also have associated costs. Next, we'll drill into the costs of this application by using these dimensions.
 
 To do this click on the setting button next to <b>Aggregate by</b> at the top right.
 
@@ -32,7 +32,7 @@ Then under <b>Filters</b> select <b>label</b> from the drop-down menu, enter the
 <img src={require('@site/static/docs/observability/kubecost/costallocation-label.webp').default}/>
 </Browser>
 
-This filters down the namespaces to only show our workloads that have the label `app.kubernetes.io/create-by: eks-workshop`. This label is included on all the components of the application we launched in the Introduction section.
+This filters down the namespaces to only show our workloads that have the label `app.kubernetes.io/created-by: eks-workshop`. This label is included on all the components of the application we launched in the Introduction section.
 
 Now click on <b>Aggregate by</b> and choose <b>Deployment</b>. This will aggregate the costs by deployment instead of by namespace. See below.
 

--- a/website/docs/observability/kubecost/introduction.md
+++ b/website/docs/observability/kubecost/introduction.md
@@ -3,7 +3,7 @@ title: "Introduction"
 sidebar_position: 10
 ---
 
-The first thing we'll do is install Kubecost in our cluster. As part of the lab preparation an the AWS Load Balancer Controller and EBS CSI driver were pre-installed to provide ingress and storage to Kubecost.
+The first thing we'll do is install Kubecost in our cluster. As part of the lab preparation, the AWS Load Balancer Controller and EBS CSI driver were pre-installed to provide ingress and storage to Kubecost.
 
 All that we have left to do is install Kubecost as a Helm chart:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes issues found during the EKS Workshop bug bash in the Kubecost (Cost visibility) module:
  
  * introduction.md: fix broken phrase "an the AWS Load Balancer Controller" → "the AWS Load Balancer Controller"
  * costallocation.md: complete the incomplete sentence "These components also have." → "These components also have associated costs."
  * costallocation.md: standardize the label to `app.kubernetes.io/created-by` (was `create-by`, missing "d"), which would return zero results if copied into the filter

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [x] My content adheres to the style guidelines
- [x] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
