### PR TITLE
fix: Build only en locale in PR website check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,11 @@ jobs:
         run: |
           export LAB_TIMES_ENABLED='true'
           yarn install
-          yarn workspace website build
+          # Build only the default (en) locale on PRs. Translations for newly
+          # added modules are produced post-merge by the auto-translate workflow
+          # (push to main), so a full multi-locale build here fails the broken
+          # links check on untranslated pages. The full build runs on publish.
+          yarn workspace website build --locale en
 
   build-lab:
     name: "Build lab"


### PR DESCRIPTION
The PR build-website job ran a full multi-locale docusaurus build, but translations for newly added modules are generated post-merge by the auto-translate workflow (push to main). Building the ja locale on a PR therefore fails the onBrokenLinks check on untranslated fallback pages (a new module's cross-module relative .md links cannot resolve in ja).

Restrict the PR build to the default en locale. The full multi-locale build still runs on publish (hack/publish-content.sh / publish-snapshot.sh), after auto-translate has generated the translations.

<!-- Please make sure your PR title contains the appropriate prefix:

new:           <-- A new lab
update:        <-- Content updates to an existing lab
fix:           <-- Changes that resolve issues such as broken content or typos
feat:          <-- A update to the core website, tools etc.
chore:         <-- Changes to the repository such as CI, scripts
docs:          <-- Documentation changes that do not impact code

Examples:

update: Added a new topic to <lab name>

fix: Fixed spelling issues in <lab name>

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Quality checks

- [ ] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md)
- [ ] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
