### PR TITLE
docs: Documented VPC BPA prerequisite 

### DIFF
--- a/website/docs/introduction/setup/your-account/index.md
+++ b/website/docs/introduction/setup/your-account/index.md
@@ -12,6 +12,29 @@ Provisioning this workshop environment in your AWS account will create resources
 
 This section outlines how to set up the environment to run the labs in your own AWS account.
 
+### VPC Block Public Access prerequisite
+
+The default IDE template creates a public EC2 instance and requires outbound
+HTTPS access to AWS Systems Manager, Amazon S3, GitHub, and COPR package
+repositories.
+
+If your account uses Amazon VPC Block Public Access, the default template can
+fail because direct Internet Gateway traffic from the IDE instance is blocked.
+Before launching the template, verify that the workshop VPC can make the
+required outbound HTTPS connections.
+
+Possible approaches include:
+
+- Use an account or VPC that permits the required outbound HTTPS access
+- Use a NAT Gateway-based network design
+- Create a scoped VPC Block Public Access exclusion for the temporary workshop
+  VPC, subject to your account's security policies
+
+Do not disable account-wide VPC Block Public Access unless that is approved for
+your environment.
+
+### Copy the CloudFormation IDE template
+
 The first step is to create an IDE with the provided CloudFormation templates. Use the AWS CloudFormation quick-create links below to launch the desired template in the appropriate AWS region.
 
 | Region           | Link                                                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
#### What this PR does / why we need it:
 Documents an IDE setup prerequisite for accounts that use Amazon VPC Block Public Access (BPA).

The default IDE CloudFormation template creates a public EC2 instance and expects it to access Systems Manager, S3-backed Amazon Linux repositories, GitHub, and COPR over outbound HTTPS. In accounts with VPC BPA enabled, users can see SSM registration failures, package repository timeouts, and GitHub connectivity failures.
  
This change adds:
  - A VPC Block Public Access prerequisite and recommended approaches
  - Guidance that users should not disable account-wide BPA without approval
  
#### Which issue(s) this PR fixes:

Related to #1928

#### Quality checks

- [x] My content adheres to the style guidelines
- [ ] I ran `make test module="<module>"` it was successful (see https://github.com/aws-samples/eks-workshop-v2/blob/main/docs/automated_tests.md) --> _only made a documentation change_
- [x] The PR has meaningful title and description of the changes that will be included in the workshop release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.